### PR TITLE
update setup.py when having ./cpptraj folder but does not have libcpptraj

### DIFF
--- a/installs/install_cpptraj_current_folder.sh
+++ b/installs/install_cpptraj_current_folder.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# PYTRAJHOME is the root folder of `pytraj`
+export PYTRAJHOME=`pwd`
+cd cpptraj/
+export CPPTRAJHOME=`pwd`
+cd $CPPTRAJHOME
+mkdir lib
+
+# turn off openmp. need to install pytraj with opnmp too. Too complicated.
+make libcpptraj -j8 || bash ./configure -shared gnu || bash ./configure -nomathlib -shared gnu || bash ./configure -amberlib -shared gnu || make libcpptraj -j8 || exit 1
+cd $PYTRAJHOME

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ list_of_libcpptraj = glob(os.path.join(libdir, 'libcpptraj') + '*')
 if not list_of_libcpptraj:
     if do_install or do_build:
         if has_cpptraj_in_current_folder:
-            print('can not find libcpptraj, trying to reinstall it to ./cpptraj/lib/ \n')
+            print('can not find libcpptraj but found ./cpptraj folder, trying to reinstall it to ./cpptraj/lib/ \n')
             sleep(3)
             try:
                 subprocess.check_call(['sh', './installs/install_cpptraj_current_folder.sh'])

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,16 @@ extra_link_args=['-O0',]
 list_of_libcpptraj = glob(os.path.join(libdir, 'libcpptraj') + '*')
 if not list_of_libcpptraj:
     if do_install or do_build:
-        raise RuntimeError('can not find libcpptraj in $CPPTRAJHOME/lib or ./cpptraj/lib folder. '
+        if has_cpptraj_in_current_folder:
+            print('can not find libcpptraj, trying to reinstall it to ./cpptraj/lib/ \n')
+            sleep(3)
+            try:
+                subprocess.check_call(['sh', './installs/install_cpptraj_current_folder.sh'])
+            except CalledProcessError:
+                sys.stderr.write('can not install libcpptraj, you need to install it manually \n')
+                sys.exit(1)
+        else:
+            raise RuntimeError('can not find libcpptraj in $CPPTRAJHOME/lib. '
                            'You need to install ``libcpptraj`` manually. '
                            )
 

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ else:
             subprocess.check_call(['sh', './installs/install_cpptraj_git.sh'])
         except CalledProcessError:
             sys.stderr.write('can not install libcpptraj, you need to install it manually \n')
-            sys.exit(1)
+            sys.exit(0)
     cpptraj_dir = os.path.join(rootname, "cpptraj")
     cpptraj_include = os.path.join(cpptraj_dir, 'src')
     libdir =  os.path.join(cpptraj_dir, 'lib')
@@ -149,7 +149,7 @@ if not list_of_libcpptraj:
                 subprocess.check_call(['sh', './installs/install_cpptraj_current_folder.sh'])
             except CalledProcessError:
                 sys.stderr.write('can not install libcpptraj, you need to install it manually \n')
-                sys.exit(1)
+                sys.exit(0)
         else:
             raise RuntimeError('can not find libcpptraj in $CPPTRAJHOME/lib. '
                            'You need to install ``libcpptraj`` manually. '
@@ -256,11 +256,11 @@ datalist_match = (sorted(datalist) == sorted(setup_for_amber.datalist))
 
 if not package_match:
     sys.stderr.write("packages mistmatch. Make sure to update ./scripts/setup_for_amber.py\n")
-    sys.exit(1)
+    sys.exit(0)
 
 if not datalist_match:
     sys.stderr.write("datalist mistmatch\n")
-    sys.exit(1)
+    sys.exit(0)
     
 def build_func(my_ext):
     return setup(name="pytraj",


### PR DESCRIPTION
This is how pytraj's setup currently work.

+ First, it will check if there is $CPPTRAJHOME env. If not, it will check if there is ./cpptraj in current folder

+ Then it will check if there is ``libcpptraj.so`` in $CPPTRAJHOME/lib or ./cpptraj/lib. If existing ./cpptraj/, pytraj will try to reinstall ``libcpptraj``.

This PR enhance this #800 