### PR TITLE
add load_batch

### DIFF
--- a/pytraj/__init__.py
+++ b/pytraj/__init__.py
@@ -83,6 +83,7 @@ load_from_frame_iter = _load_from_frame_iter
 
 # dataset stuff
 from .datafiles.load_sample_data import load_sample_data
+from .datafiles.datafiles import load_batch
 from .datasetlist import DatasetList
 
 # tool

--- a/pytraj/core/cpptraj_core.pyx
+++ b/pytraj/core/cpptraj_core.pyx
@@ -493,6 +493,16 @@ cdef class CpptrajState:
     def __dealloc__(self):
         if self.thisptr is not NULL:
             del self.thisptr
+
+    def __str__(self):
+        return 'CpptrajState, include:\n' + '<datasetlist: {0} datasets>'.format(len(self.data))
+
+    property data:
+        def __get__(self):
+            return self.datasetlist
+
+    def __repr__(self):
+        return str(self)
     
     def is_empty(self):
         return self.thisptr.EmptyState()

--- a/pytraj/core/cpptraj_core.pyx
+++ b/pytraj/core/cpptraj_core.pyx
@@ -442,6 +442,8 @@ cdef extern from "Command.h":
     cdef cppclass _Command "Command":
         @staticmethod
         RetType ProcessInput(_CpptrajState&, const string&)
+        @staticmethod
+        RetType Dispatch(_CpptrajState&, const string&)
 
 cdef class Command:
     cdef _Command* thisptr
@@ -457,6 +459,13 @@ cdef class Command:
         cdef CpptrajState cppstate = CpptrajState()
         trajin_text = trajin_text.encode()
         _Command.ProcessInput(cppstate.thisptr[0], trajin_text)
+        return cppstate
+
+    @classmethod
+    def get_state_from_string(cls, txt):
+        cdef CpptrajState cppstate = CpptrajState()
+        trajin_text = txt.encode()
+        _Command.Dispatch(cppstate.thisptr[0], trajin_text)
         return cppstate
 
 cdef class CpptrajState:

--- a/pytraj/datafiles/datafiles.pyx
+++ b/pytraj/datafiles/datafiles.pyx
@@ -1,5 +1,17 @@
 # distutils: language = c++
 
+from libcpp.string cimport string
+from ..core.cpptraj_core cimport CpptrajState, _CpptrajState
+
+cdef extern from "Command.h": 
+    ctypedef enum RetType "Command::RetType":
+        pass
+    cdef cppclass _Command "Command":
+        @staticmethod
+        RetType ProcessInput(_CpptrajState&, const string&)
+        @staticmethod
+        RetType Dispatch(_CpptrajState&, const string&)
+
 
 cdef class DataFile:
     def __cinit__(self, py_free_mem=True):
@@ -26,3 +38,30 @@ cdef class DataFileList:
 
     def write_all_datafiles(self):
         self.thisptr.WriteAllDF()
+
+def load_batch(traj, txt):
+    '''
+    '''
+    from pytraj import TrajectoryIterator
+    state = CpptrajState()
+
+    if not isinstance(traj, TrajectoryIterator):
+        raise ValueError('traj must by TrajectoryIterator, '
+                         'use pytraj.iterload(...)')
+
+    txt0 = '''
+    parm %s
+    ''' % traj.top.filename
+
+    for fname, frame_slice in zip(traj.filelist, traj.frame_slice_list):
+        start, stop, stride = frame_slice
+        if stop == -1:
+            _stop  = 'last'
+        else:
+            _stop = stop
+        txt0 += 'trajin {0} {1} {2} {3}'.format(fname, str(start), str(_stop), str(stride))
+
+    lines = (txt0 + txt).lstrip().rstrip().split('\n')
+    for line in lines:
+        _Command.Dispatch(state.thisptr[0], line.encode())
+    return state

--- a/pytraj/datafiles/datafiles.pyx
+++ b/pytraj/datafiles/datafiles.pyx
@@ -57,6 +57,8 @@ def load_batch(traj, txt):
         start, stop, stride = frame_slice
         if stop == -1:
             _stop  = 'last'
+        elif stop < -1:
+            raise RuntimeError('does not support negative stop for load_batch (except -1 (last))')
         else:
             _stop = stop
         txt0 += 'trajin {0} {1} {2} {3}'.format(fname, str(start), str(_stop), str(stride))

--- a/tests/test_load_state.py
+++ b/tests/test_load_state.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import unittest
+import pytraj as pt
+from pytraj.utils import eq, aa_eq
+from pytraj import load_batch
+
+
+class TestState(unittest.TestCase):
+    def test_loading(self):
+        for frame_slice in [(0, -1, 1), (0, 8, 2)]:
+            traj = pt.iterload('data/tz2.nc', './data/tz2.parm7', frame_slice=frame_slice)
+
+            text = '''
+            rms @CA
+            radgyr @CA nomax
+            '''
+       
+            s = load_batch(traj, text)
+            s.run()
+
+            dslist = s.datasetlist
+            rmsd0 = pt.rmsd(traj, 0, '@CA')
+            r0 = pt.radgyr(traj, '@CA')
+            aa_eq(rmsd0, dslist[0])
+            aa_eq(r0, dslist[1])
+            assert len(dslist[0]) == traj.n_frames 
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_load_state.py
+++ b/tests/test_load_state.py
@@ -26,6 +26,17 @@ class TestState(unittest.TestCase):
             aa_eq(r0, dslist[1])
             assert len(dslist[0]) == traj.n_frames 
 
+    def test_raise_if_not_trajiter(self):
+        traj = pt.iterload('data/tz2.nc', './data/tz2.parm7')
+        t0 = traj[:]
+
+        text = '''
+        rms @CA
+        radgyr @CA nomax
+        '''
+       
+        self.assertRaises(ValueError, lambda: load_batch(t0, text))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
something like

```python
            traj = pt.iterload('data/tz2.nc', './data/tz2.parm7', frame_slice=frame_slice)

            text = '''
            rms @CA
            radgyr @CA nomax
            '''
       
            s = load_batch(traj, text)
            s.run()

            dslist = s.datasetlist
```

Advantages:

* if people prefer to use `cpptraj`'s style
```
parm ./data/tz2.parm7
trajin ./data/tz2.nc
rms @CA
radgyr @CA nomax
```
and dump data directly without writing to file (from `datasetlist`)

*  Speed: all the caluclations were performed at cpptraj's level with zezo python-overhead. And avoid loading traj few times.

* suitable for multiple actions like 'autoimage', 'center'
```
parm ./data/tz2.parm7
trajin ./data/tz2.nc
autoimage
center
rms @CA
radgyr @CA nomax
```

* get benefit from ``pytraj``, such as loading a bunch of files easily
```
traj = pt.iterload('traj.*.nc', 'tz2.parm7')
```