### PR TITLE
naive support parallel with cpptraj commands

### DIFF
--- a/pytraj/common_actions.py
+++ b/pytraj/common_actions.py
@@ -1017,6 +1017,7 @@ def do_autoimage(traj=None, command="", frame_indices=None, top=None):
 autoimage = do_autoimage
 
 
+@_register_pmap
 def mean_structure(traj,
                    mask='',
                    frame_indices=None,

--- a/pytraj/pmap.py
+++ b/pytraj/pmap.py
@@ -1,5 +1,27 @@
 from functools import partial
 from pytraj.cpp_options import info as compiled_info
+from collections import OrderedDict
+import numpy as np
+from pytraj.externals.six import string_types, iteritems
+
+
+def concat_dict(iterables):
+    # we have this function in pytraj.tools but copy here to be used as internal method
+    # TODO: fill missing values?
+    """concat dict
+
+    iterables : iterables that produces OrderedDict
+    """
+    new_dict = OrderedDict()
+    for i, d in enumerate(iterables):
+        if i == 0:
+            # make a copy of first dict
+            new_dict.update(d)
+        else:
+            for k, v in iteritems(new_dict):
+                new_dict[k] = np.concatenate((new_dict[k], d[k]))
+    return new_dict
+
 
 def worker(rank,
            n_cores=None,
@@ -14,7 +36,14 @@ def worker(rank,
 
 
 def pmap(n_cores=2, func=None, traj=None, *args, **kwd):
-    '''
+    '''use python's multiprocessing to accelerate calculation. Limited calculations.
+
+    Parameters
+    ----------
+    n_cores : int, number of cores to be used, default 2
+    func : a pytraj's methods or a list of string or simply as a cpptraj' text
+    traj : pytraj.TrajectoryIterator
+    *args, **kwd: additional keywords
 
     Returns
     -------
@@ -53,24 +82,31 @@ def pmap(n_cores=2, func=None, traj=None, *args, **kwd):
     from multiprocessing import Pool
     from pytraj import TrajectoryIterator
 
-    if not hasattr(func, '_is_parallelizable') or not func._is_parallelizable:
-        raise ValueError("this method does not support parallel")
+    if isinstance(func, (list, tuple, string_types)):
+        # assume using _load_batch_pmap
+        from pytraj.parallel import _load_batch_pmap
+        data = _load_batch_pmap(n_cores=n_cores, traj=traj, lines=func, dtype='dict', root=0, mode='multiprocessing')
+        return concat_dict((x[1] for x in data))
     else:
-        if hasattr(func, '_openmp_capability') and func._openmp_capability and 'OPENMP' in compiled_info():
-            raise RuntimeError("this method supports both openmp and pmap, but your cpptraj "
-            "version was installed with openpm. Should not use both openmp and pmap at the "
-            "same time. In this case, do not use pmap since openmp is more efficient")
+        # pytraj's method
+        if not hasattr(func, '_is_parallelizable') or not func._is_parallelizable:
+            raise ValueError("this method does not support parallel")
+        else:
+            if hasattr(func, '_openmp_capability') and func._openmp_capability and 'OPENMP' in compiled_info():
+                raise RuntimeError("this method supports both openmp and pmap, but your cpptraj "
+                "version was installed with openpm. Should not use both openmp and pmap at the "
+                "same time. In this case, do not use pmap since openmp is more efficient")
 
-    if not isinstance(traj, TrajectoryIterator):
-        raise ValueError('only support TrajectoryIterator')
+        if not isinstance(traj, TrajectoryIterator):
+            raise ValueError('only support TrajectoryIterator')
 
-    p = Pool(n_cores)
-    pfuncs = partial(worker,
-                     n_cores=n_cores,
-                     func=func,
-                     traj=traj,
-                     args=args,
-                     kwd=kwd)
-    result = p.map(pfuncs, [rank for rank in range(n_cores)])
-    p.close()
-    return result
+        p = Pool(n_cores)
+        pfuncs = partial(worker,
+                         n_cores=n_cores,
+                         func=func,
+                         traj=traj,
+                         args=args,
+                         kwd=kwd)
+        result = p.map(pfuncs, [rank for rank in range(n_cores)])
+        p.close()
+        return result

--- a/tests/test_pmap.py
+++ b/tests/test_pmap.py
@@ -74,6 +74,16 @@ class TestParallelMapForMatrix(unittest.TestCase):
             y = np.sum((val[1] * val[2] for val in x), axis=1)
             aa_eq(y/traj.n_frames, func(traj, '@CA'))
 
+class TestCpptrajCommandStyle(unittest.TestCase):
+    def test_cpptraj_command_style(self):
+        traj = pt.iterload("data/tz2.nc", "data/tz2.parm7")
+
+        angle_ = pt.angle(traj, ':3 :4 :5')
+        distance_ = pt.distance(traj, '@10 @20')
+
+        data = pt.pmap(4, ['angle :3 :4 :5', 'distance @10 @20'], traj)
+        aa_eq(angle_, data['Ang_00002'])
+        aa_eq(distance_, data['Dis_00003'])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
```python
data = pt.pmap(4, ['angle :3 :4 :5', 'distance @10 @20'], traj)
```

The output still looks ugly, but I think it does its job.

```python
OrderedDict([('Ang_00002', array([ 69.68716988,  60.2844541 ,  54.42705162, ...,  71.3034791 ,
        54.10386015,  65.28664506])), 
('Dis_00003', array([ 3.91279372,  3.90062135,  4.53520013, ...,  6.5440018 ,
        5.95743058,  6.91264439]))])
```