### PR TITLE
add create_pipeline for lazy computing

### DIFF
--- a/pytraj/__init__.py
+++ b/pytraj/__init__.py
@@ -38,7 +38,7 @@ except ImportError:
 
 try:
     from .core import Atom, Residue, Molecule
-    from .core.ActionList import ActionList
+    from .core.ActionList import ActionList, create_pipeline
     Pipeline = ActionList
 except ImportError:
     import os

--- a/pytraj/core/ActionList.pyx
+++ b/pytraj/core/ActionList.pyx
@@ -11,6 +11,30 @@ def _get_arglist(arg):
     else:
         return ArgList(arg)
 
+def create_pipeline(traj, commands, DatasetList dslist=DatasetList()):
+    '''create frame iterator from cpptraj's commands
+
+    Parameters
+    ----------
+    commands : a list of strings
+    traj : Trajectory or any iterable that produces Frame
+    dslist : CpptrajDatasetList, optional
+
+    Examples
+    --------
+    >>> import pytraj as pt
+    >>> traj = pt.load_sample_data('tz2')
+    >>> for frame in pt.create_pipeline(traj, ['autoimage', 'rms']): print(frame)
+    '''
+    cdef Frame frame
+    cdef ActionList actlist
+
+    actlist = ActionList(commands, top=traj.top, dslist=dslist) 
+    for frame in iterframe_master(traj):
+        actlist.do_actions(frame)
+        yield frame
+
+
 cdef class ActionList:
     def __cinit__(self):
         self.thisptr = new _ActionList()

--- a/pytraj/core/ActionList.pyx
+++ b/pytraj/core/ActionList.pyx
@@ -16,7 +16,7 @@ def create_pipeline(traj, commands, DatasetList dslist=DatasetList()):
 
     Parameters
     ----------
-    commands : a list of strings
+    commands : a list of strings of cpptraj's Action commands
     traj : Trajectory or any iterable that produces Frame
     dslist : CpptrajDatasetList, optional
 

--- a/tests/test_ActionList.py
+++ b/tests/test_ActionList.py
@@ -385,6 +385,13 @@ class TestActionList(unittest.TestCase):
         saved_rmsd_ = pt.rmsd_nofit(t0, ref=ref)
         aa_eq(rmsd_nofit_after_fitting, saved_rmsd_)
 
+    def test_create_frame_iterator(self):
+        traj = pt.iterload("data/tz2.ortho.nc", "data/tz2.ortho.parm7")
+        fi = pt.create_pipeline(traj, ['autoimage', 'rms'])
+        xyz = np.array([frame.xyz.copy() for frame in fi])
+        t0 = traj[:].autoimage().superpose()
+        aa_eq(xyz, t0.xyz)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_run_docstring.py
+++ b/tests/test_run_docstring.py
@@ -37,6 +37,7 @@ class Test(unittest.TestCase):
 
         funclist = [DataArray,
                     pt.actions.CpptrajActions.Action,
+                    pt.create_pipeline,
                     pt.pmap,
                     pt.nastruct,
                     pt.mean_structure,


### PR DESCRIPTION
```python
In [1]: pt.create_pipeline(traj, ['autoimage', 'rms', 'center'])
Out[1]: <generator at 0x2aaad39e39c8>
```

just like cpptraj's command below but the current (modified) state of Frame is kept. We can freely to play further with this state. It's layz because we don't actually do anything.

```python
parm prmtop
trajin traj.nc
autoimage
rms
center
```

This make user much easier to plug his/her method to cpptraj's stream

```python
def new_method(traj, ...):
    for frame in traj:
        do_some_thing_fun(frame)
        yield frame

fi = pt.create_pipeline(traj, ['autoimage', 'rms', 'center'])
new_method(fi) 
# Frame is passed to `new_method` and each Frame will be processed by cpptraj ('autoimage',
# 'rms', 'center') before passing to `new_method`)