### PR TITLE
consistent API for pmap_mpi

### DIFF
--- a/examples/mpi_examples/pmap_mpi_0.py
+++ b/examples/mpi_examples/pmap_mpi_0.py
@@ -1,0 +1,33 @@
+# always add those lines to your code
+import numpy as np
+from mpi4py import MPI
+import pytraj as pt
+from pytraj.parallel import pmap_mpi
+from pytraj.testing import aa_eq
+
+comm = MPI.COMM_WORLD
+# end. you are free to update anything below here
+
+# split remd.x.000 to N cores and do calc_surf in parallel
+root_dir = "../../tests/data/"
+traj_name = root_dir + "tz2.ortho.nc"
+parm_name = root_dir + "tz2.ortho.parm7"
+
+# load to TrajectoryIterator
+traj = pt.iterload(traj_name, parm_name)
+
+# save `total_arr` to rank=0
+# others: total_arr = None
+total_arr = pmap_mpi(['autoimage', 'center :2', 'distance :3 :7', 'angle :3 :7 :8'], traj)
+
+if comm.rank != 0:
+    assert total_arr is None
+
+if comm.rank == 0:
+    # assert to serial
+    from pytraj.tools import dict_to_ndarray
+    arr = dict_to_ndarray(total_arr)
+
+    t0 = pt.center(traj[:].autoimage(), ':2')
+    aa_eq(pt.distance(t0, ':3 :7'), arr[0])
+    aa_eq(pt.angle(t0, ':3 :7 :8'), arr[1])

--- a/examples/mpi_examples/pmap_mpi_0.py
+++ b/examples/mpi_examples/pmap_mpi_0.py
@@ -27,6 +27,7 @@ if comm.rank == 0:
     # assert to serial
     from pytraj.tools import dict_to_ndarray
     arr = dict_to_ndarray(total_arr)
+    print(total_arr)
 
     t0 = pt.center(traj[:].autoimage(), ':2')
     aa_eq(pt.distance(t0, ':3 :7'), arr[0])

--- a/pytraj/parallel/__init__.py
+++ b/pytraj/parallel/__init__.py
@@ -1,3 +1,5 @@
+import numpy as np
+from pytraj.externals.six import string_types, iteritems
 from .parallel_mapping_mpi import pmap_mpi
 from .parallel_mapping_multiprocessing import pmap
 from pytraj.tools import concat_dict
@@ -6,6 +8,25 @@ from functools import partial
 from pytraj import Frame
 from pytraj import create_pipeline
 from pytraj.datasets import CpptrajDatasetList
+from collections import OrderedDict
+
+def _concat_dict(iterables):
+    # we have this function in pytraj.tools but copy here to be used as internal method
+    # TODO: fill missing values?
+    """concat dict
+
+    iterables : iterables that produces OrderedDict
+    """
+    new_dict = OrderedDict()
+    for i, d in enumerate(iterables):
+        if i == 0:
+            # make a copy of first dict
+            new_dict.update(d)
+        else:
+            for k, v in iteritems(new_dict):
+                new_dict[k] = np.concatenate((new_dict[k], d[k]))
+    return new_dict
+
 
 def _worker_actlist(rank, n_cores=2, traj=None, lines=[], dtype='dict', ref=None):
     # need to make a copy if lines since python's list is dangerous
@@ -91,7 +112,9 @@ def _load_batch_pmap(n_cores=4, lines=[], traj=None, dtype='dict', root=0,
         comm = MPI.COMM_WORLD
         size = comm.size
         rank = comm.rank
-        data_chunk = _worker_state(rank, n_cores=size, traj=traj, lines=lines, dtype=dtype)
+        #data_chunk = _worker_state(rank, n_cores=size, traj=traj, lines=lines, dtype=dtype)
+        data_chunk = _worker_actlist(rank=rank, n_cores=n_cores, traj=traj, dtype=dtype,
+                lines=lines, ref=ref)
         # it's ok to use python level `gather` method since we only do this once
         # only gather data to root, other cores get None
         data = comm.gather(data_chunk, root=root)

--- a/pytraj/parallel/__init__.py
+++ b/pytraj/parallel/__init__.py
@@ -10,23 +10,6 @@ from pytraj import create_pipeline
 from pytraj.datasets import CpptrajDatasetList
 from collections import OrderedDict
 
-def _concat_dict(iterables):
-    # we have this function in pytraj.tools but copy here to be used as internal method
-    # TODO: fill missing values?
-    """concat dict
-
-    iterables : iterables that produces OrderedDict
-    """
-    new_dict = OrderedDict()
-    for i, d in enumerate(iterables):
-        if i == 0:
-            # make a copy of first dict
-            new_dict.update(d)
-        else:
-            for k, v in iteritems(new_dict):
-                new_dict[k] = np.concatenate((new_dict[k], d[k]))
-    return new_dict
-
 
 def _worker_actlist(rank, n_cores=2, traj=None, lines=[], dtype='dict', ref=None):
     # need to make a copy if lines since python's list is dangerous

--- a/pytraj/parallel/parallel_mapping_mpi.py
+++ b/pytraj/parallel/parallel_mapping_mpi.py
@@ -1,5 +1,6 @@
 import numpy as np
 from pytraj.utils import split_range
+from pytraj.tools import concat_dict
 
 def pmap_mpi(func, traj, *args, **kwd):
     """parallel with MPI (mpi4py)
@@ -55,7 +56,7 @@ def pmap_mpi(func, traj, *args, **kwd):
         data = func(fa_chunk, *args, **kwd)
         total = comm.gather(data, root=0)
     else:
-        from pytraj.parallel import _load_batch_pmap, _concat_dict
+        from pytraj.parallel import _load_batch_pmap, concat_dict
         if 'dtype' in kwd.keys():
             kwd.pop('dtype')
         if 'dtype' in kwd.keys():
@@ -64,5 +65,5 @@ def pmap_mpi(func, traj, *args, **kwd):
                                 root=0, mode='mpi', **kwd)
         if rank == 0:
             # otherwise, total=None
-            total = _concat_dict((x[1] for x in total))
+            total = concat_dict((x[1] for x in total))
     return total

--- a/pytraj/parallel/parallel_mapping_mpi.py
+++ b/pytraj/parallel/parallel_mapping_mpi.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pytraj.utils import split_range
 
-def pmap_mpi(func, traj, command, dtype='ndarray', *args, **kwd):
+def pmap_mpi(func, traj, *args, **kwd):
     """parallel with MPI (mpi4py)
 
     Parameters
@@ -44,16 +44,25 @@ def pmap_mpi(func, traj, command, dtype='ndarray', *args, **kwd):
     """
     from mpi4py import MPI
     comm = MPI.COMM_WORLD 
-    size = comm.size
+    n_cores = comm.size
     rank = comm.rank
 
-    # split traj to ``size`` chunks, perform calculation 
-    # for rank-th chunk
-    start, stop = split_range(size, 0, traj.n_frames)[rank]
-    fa_chunk = traj(start=start, stop=stop) 
-
-    dslist = func(fa_chunk, command, dtype=dtype, *args, **kwd)
-
-    # gather data to root
-    total = comm.gather(dslist, root=0)
+    if not isinstance(func, (list, tuple)):
+        # split traj to ``n_cores`` chunks, perform calculation 
+        # for rank-th chunk
+        start, stop = split_range(n_cores, 0, traj.n_frames)[rank]
+        fa_chunk = traj(start=start, stop=stop) 
+        data = func(fa_chunk, *args, **kwd)
+        total = comm.gather(data, root=0)
+    else:
+        from pytraj.parallel import _load_batch_pmap, _concat_dict
+        if 'dtype' in kwd.keys():
+            kwd.pop('dtype')
+        if 'dtype' in kwd.keys():
+            kwd.pop('dtype')
+        total = _load_batch_pmap(n_cores=n_cores, traj=traj, lines=func, dtype='dict',
+                                root=0, mode='mpi', **kwd)
+        if rank == 0:
+            # otherwise, total=None
+            total = _concat_dict((x[1] for x in total))
     return total

--- a/pytraj/parallel/parallel_mapping_multiprocessing.py
+++ b/pytraj/parallel/parallel_mapping_multiprocessing.py
@@ -12,8 +12,8 @@ from pytraj import Frame
 from pytraj import ired_vector_and_matrix, rotation_matrix
 from pytraj import NH_order_parameters
 from pytraj import search_hbonds
-from pytraj.parallel import _concat_dict
 from multiprocessing import cpu_count
+from pytraj.tools import dict_to_ndarray, concat_dict
 
 
 def _worker(rank,
@@ -182,16 +182,15 @@ def _pmap(func, traj, *args, **kwd):
 
     if isinstance(func, (list, tuple)):
         # assume using _load_batch_pmap
-        from pytraj.parallel import _load_batch_pmap, _concat_dict
+        from pytraj.parallel import _load_batch_pmap
         if 'dtype' in kwd.keys():
             kwd.pop('dtype')
         data = _load_batch_pmap(n_cores=n_cores, traj=traj, lines=func, dtype='dict',
                 root=0, mode='multiprocessing', **kwd)
-        data = _concat_dict((x[1] for x in data))
+        data = concat_dict((x[1] for x in data))
         if dtype == 'dict' or dtype is None:
             return data
         elif dtype == 'ndarray':
-            from pytraj.tools import dict_to_ndarray
             return dict_to_ndarray(data)
         else:
             raise ValueError("if using func as a list/tuple, dtype must be 'ndarray' or 'dict'")
@@ -250,7 +249,7 @@ def _pmap(func, traj, *args, **kwd):
             return frame
         else:
             if dtype in ['dict',]:
-                return _concat_dict((x[1] for x in data))
+                return concat_dict((x[1] for x in data))
             elif dtype in ['dataset',] and func != search_hbonds:
                 return stack((x[1] for x in data))
             else:

--- a/pytraj/parallel/parallel_mapping_multiprocessing.py
+++ b/pytraj/parallel/parallel_mapping_multiprocessing.py
@@ -12,6 +12,7 @@ from pytraj import Frame
 from pytraj import ired_vector_and_matrix, rotation_matrix
 from pytraj import NH_order_parameters
 from pytraj import search_hbonds
+from pytraj.parallel import _concat_dict
 from multiprocessing import cpu_count
 
 

--- a/pytraj/parallel/parallel_mapping_multiprocessing.py
+++ b/pytraj/parallel/parallel_mapping_multiprocessing.py
@@ -15,24 +15,6 @@ from pytraj import search_hbonds
 from multiprocessing import cpu_count
 
 
-def _concat_dict(iterables):
-    # we have this function in pytraj.tools but copy here to be used as internal method
-    # TODO: fill missing values?
-    """concat dict
-
-    iterables : iterables that produces OrderedDict
-    """
-    new_dict = OrderedDict()
-    for i, d in enumerate(iterables):
-        if i == 0:
-            # make a copy of first dict
-            new_dict.update(d)
-        else:
-            for k, v in iteritems(new_dict):
-                new_dict[k] = np.concatenate((new_dict[k], d[k]))
-    return new_dict
-
-
 def _worker(rank,
            n_cores=None,
            func=None,
@@ -199,7 +181,7 @@ def _pmap(func, traj, *args, **kwd):
 
     if isinstance(func, (list, tuple)):
         # assume using _load_batch_pmap
-        from pytraj.parallel import _load_batch_pmap
+        from pytraj.parallel import _load_batch_pmap, _concat_dict
         if 'dtype' in kwd.keys():
             kwd.pop('dtype')
         data = _load_batch_pmap(n_cores=n_cores, traj=traj, lines=func, dtype='dict',


### PR DESCRIPTION
#### consistent API for pmap_mpi and pmap

* mpi mode
```
pmap_mpi(pt.radgyr, traj) # don't need to provide n_cores here. We use `mpirun -n 4 ...`
```

Ideally, we should only have one `pmap` method but this make the code a bit more complicated. so just make them `pmap` for `multiprocessing` and `pmap_mpi` for `MPI`.

* multiprocessing mode
```
pmap(pt.radgyr, traj, n_cores=4)
```

#### The biggest change here is that we can use a series of cpptraj's command (not only pytraj's method)

```python
pmap_mpi(['autoimage', 'center :2', 'distance :3 :7', 'angle :3 :7 :8'], traj)
```

output:
```python
OrderedDict([('Dis_00000', array([  9.48439863,   9.79616302,   9.35450479,   9.57256816,
        10.09955627,   9.6236227 ,  10.36017486,  10.04639645,
        10.03293064,   9.45615558])), ('Ang_00001', array([ 74.91719744,  69.71458237,  
74.35604139,  78.17689569,
        76.70314718,  77.91747126,  75.12749319,  77.83048564,
        79.6697457 ,  82.159786  ]))])
```

#### Advantage

We only need to install `libcpptraj` with `-openmp` flag to enjoy different parallel schemes.