### PR TITLE
support force: only work with TrajectoryIterator from iterload for now

### DIFF
--- a/pytraj/Frame.pxd
+++ b/pytraj/Frame.pxd
@@ -19,13 +19,11 @@ cdef extern from "Frame.h" nogil:
         POINT "Frame::POINT"
     cdef cppclass _Frame "Frame":
         _Frame() 
-        #~_Frame() 
         _Frame(int)
         _Frame(int, double*)
         _Frame(const vector[_Atom]&)
         _Frame(const _Frame&, const _AtomMask&)
         _Frame(const _Frame&)
-        #_Frame& operator =(_Frame)
         void SetFromCRD(const CRDtype&, int, int, bint)
         void SetFromCRD(const CRDtype&, const _AtomMask&, int, int, bint)
         CRDtype ConvertToCRD(int, bint) const 
@@ -39,6 +37,7 @@ cdef extern from "Frame.h" nogil:
         const double& operator[](int idx) const 
         bint empty() const 
         bint HasVelocity() const 
+        bint HasForce() const 
         int Natom() const 
         int size() const 
         int NrepDims() const 
@@ -47,25 +46,19 @@ cdef extern from "Frame.h" nogil:
         const double * XYZ(int atnum) const 
         const double * CRD(int idx) const 
         const double * VXYZ(int atnum) const 
+        const double * FXYZ(int atnum) const 
         double Mass(int atnum) const 
-        #const _Box& BoxCrd() const 
         _Box& BoxCrd() const 
         inline double * xAddress() 
         inline double * vAddress() 
+        inline double* fAddress()
         inline double * bAddress() 
         inline double * tAddress() 
         inline int * iAddress() 
-        #inline const double * xAddress() const 
-        #inline const double * vAddress() const 
-        #inline const double * bAddress() const 
-        #inline const double * tAddress() const 
         inline const int * iAddress() const 
         inline void SetBoxAngles(const double *)
         void SetBox(const _Box&)
-        # Set box alpha, beta, and gamma
-        # Set temperature
         void SetTemperature(double tIn)
-        # Set time
         void SetTime(double tIn)
         int SetupFrame(int)
         int SetupFrameM(const vector[_Atom]&)
@@ -82,11 +75,8 @@ cdef extern from "Frame.h" nogil:
         void ModifyByMap(const _Frame&, const vector[int]&)
         void ZeroCoords() 
         _Frame& addequal "operator +=" (const _Frame&)
-        #_Frame& operator +=(const _Frame&)
         _Frame& subequal "operator -=" (const _Frame&)
-        #_Frame& operator -= (const _Frame&)
         _Frame& mulequal "operator *=" (const _Frame&)
-        #_Frame& operator *= (const _Frame&)
         const _Frame operator *(const _Frame&) const 
         const _Frame operator -(const _Frame&) const 
         int Divide(const _Frame&, double)
@@ -105,7 +95,6 @@ cdef extern from "Frame.h" nogil:
         inline void Rotate(const _Matrix_3x3&, const _AtomMask&)
         inline void Trans_Rot_Trans(const _Vec3&, const _Matrix_3x3&, const _Vec3&)
         void Scale(const _AtomMask&, double, double, double)
-        # Not in cpptraj anymore
         void Center(const _AtomMask&, CenterMode, const _Vec3&, bint)
 
         _Vec3 CenterOnOrigin(bint)

--- a/pytraj/Frame.pyx
+++ b/pytraj/Frame.pyx
@@ -439,11 +439,21 @@ cdef class Frame (object):
             """
             cdef int n_atoms = self.n_atoms
             return np.asarray(<double[:n_atoms, :3]> self.thisptr.vAddress())
+
+    property force:
+        def __get__(self):
+            """
+            """
+            cdef int n_atoms = self.n_atoms
+            return np.asarray(<double[:n_atoms, :3]> self.thisptr.fAddress())
         
     def is_empty(self):
         return self.thisptr.empty()
 
     def has_velocity(self):
+        return self.thisptr.HasVelocity()
+
+    def has_force(self):
         return self.thisptr.HasVelocity()
 
     property n_atoms:

--- a/pytraj/__version__.py
+++ b/pytraj/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.2.dev11"
+__version__ = "0.1.2.dev12"

--- a/tests/test_force.py
+++ b/tests/test_force.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import unittest
+import pytraj as pt
+from pytraj.utils import eq, aa_eq
+from pytraj.testing import cpptraj_test_dir
+
+class TestForce(unittest.TestCase):
+    def test_nosegfault_for_force(self):
+        fn = cpptraj_test_dir + '/Test_systemVF/systemVF.nc'
+        tn = cpptraj_test_dir + '/Test_systemVF/systemVF.parm7'
+        traj = pt.iterload(fn, tn)
+
+        for f in traj:
+            assert f.has_force(), 'must have force'
+
+        print(f.force)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_force.py
+++ b/tests/test_force.py
@@ -15,7 +15,7 @@ class TestForce(unittest.TestCase):
         for f in traj:
             assert f.has_force(), 'must have force'
 
-        print(f.force)
+        #print(f.force)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
related to https://github.com/Amber-MD/cpptraj/pull/147

@ctlee

I just add force to pytraj for Frame too. Currently only work with `iterload`

```python
traj = pt.iterload('systemVF.nc', 'systemVF.parm7')
for f in traj: print(f.force)

In [5]: traj[-1].force
Out[5]:
array([[ -5.84547138,  18.11874962,   7.36161375],
       [  5.74563074, -10.81376553,  -7.01832628],
       [ -0.60432696,  -6.89329529,  -3.81471229],
       ...,
       [-17.49478149,  29.7173996 , -14.54843998],
       [  1.76848102, -26.37628555,  10.8654871 ],
       [ 12.65101337,   0.54338849,   3.11959696]])
```