### PR TITLE
fixing my freaking idiot mistake when processing Topology for ActionList

### DIFF
--- a/pytraj/core/action_list.pyx
+++ b/pytraj/core/action_list.pyx
@@ -235,6 +235,9 @@ cdef class ActionList:
 
         if not self.top_is_processed:
             self.process(self.top)
+            # make sure to make top_is_processed True after processing
+            # if not, pytraj will try to setup for every Frame
+            self.top_is_processed = True
 
         if isinstance(traj, Frame):
             frame = <Frame> traj

--- a/scripts/timing/timing_distance_actionlist.py
+++ b/scripts/timing/timing_distance_actionlist.py
@@ -1,0 +1,40 @@
+import pytraj as pt
+from pytraj.testing import Timer
+
+traj = pt.iterload('GAAC3.1000frames.nc', 'GAAC.parm7', frame_slice=(0, 1000))
+hb = pt.hbond(traj, '!:WAT')
+
+masklist = hb._amber_mask()
+cpp_cm = ['distance ' + _ for _ in masklist]
+cpp_mask = '\n'.join(cpp_cm)
+
+@Timer()
+def test_pytraj():
+    print('pytraj')
+    traj = pt.iterload('GAAC3.1000frames.nc', 'GAAC.parm7', frame_slice=(0, 1000))
+    data = pt.distance(traj, masklist)
+    #print(data)
+
+@Timer()
+def test_state():
+    print('cpptraj')
+    state = pt.load_cpptraj_state('''
+    parm GAAC.parm7
+    trajin GAAC3.1000frames.nc 1 1000
+    {0}'''.format(cpp_mask))
+    state.run()
+    #print(state.data[1:].values)
+
+test_pytraj()
+test_state()
+
+# output (1000 frames, without printing data)
+
+# pytraj (not bad)
+# 5.772035837173462
+# cpptraj
+# 4.838342905044556
+# 
+# real    0m20.512s
+# user    0m24.778s
+# sys     0m4.472s

--- a/scripts/timing/timing_distance_actionlist.py
+++ b/scripts/timing/timing_distance_actionlist.py
@@ -28,13 +28,9 @@ def test_state():
 test_pytraj()
 test_state()
 
-# output (1000 frames, without printing data)
+# timing output (seconds) with 1000 frames.
 
 # pytraj (not bad)
 # 5.772035837173462
 # cpptraj
 # 4.838342905044556
-# 
-# real    0m20.512s
-# user    0m24.778s
-# sys     0m4.472s


### PR DESCRIPTION
pytraj tried to setup Topology for every frame because the boolean flag has never set properly. damn.

Lesson learnt: always try to use `pytraj._verbose(True)` to see what cpptraj is saying.

fixing one line of code speeds up pytraj 12 times. ack.

- add timing script to make sure pytraj can catch up cpptraj's speed too.