### PR TITLE
add cpptraj text to pmap: not sure if this is a good idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tests/*nogit*
 pytraj/*bk
 tests/TestListTravis.sh
 *nogit*
+Makefile

--- a/pytraj/core/action_list.pyx
+++ b/pytraj/core/action_list.pyx
@@ -59,6 +59,11 @@ def create_pipeline(traj, commands, DatasetList dslist=DatasetList(), frame_indi
     else:
         fi = traj.iterframe(frame_indices=frame_indices)
 
+    if isinstance(commands, (list, tuple)):
+        commands = commands
+    elif isinstance(commands, string_types):
+        commands = [line.lstrip().rstrip() for line in commands.split('\n') if line.strip() != '']
+
     actlist = ActionList(commands, top=traj.top, dslist=dslist) 
     for frame in iterframe_master(fi):
         actlist.do_actions(frame)

--- a/pytraj/parallel/parallel_mapping_multiprocessing.py
+++ b/pytraj/parallel/parallel_mapping_multiprocessing.py
@@ -10,6 +10,7 @@ from pytraj import ired_vector_and_matrix, rotation_matrix
 from pytraj import NH_order_parameters
 from multiprocessing import cpu_count
 from pytraj.tools import concat_dict
+from pytraj.externals.six import string_types
 
 
 def _worker(rank,
@@ -203,7 +204,7 @@ def _pmap(func, traj, *args, **kwd):
     else:
         iter_options = {}
 
-    if isinstance(func, (list, tuple)):
+    if isinstance(func, (list, tuple, string_types)):
         # assume using _load_batch_pmap
         from pytraj.parallel import _load_batch_pmap
         data = _load_batch_pmap(n_cores=n_cores,

--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,10 @@ def do_what():
     # this checking should be here, after checking openmp and other stuff
     if len(sys.argv) == 2 and sys.argv[1] == 'install':
         do_install = True
-    elif len(sys.argv) == 3 and sys.argv[1] == 'install' and pytraj_inside_amber:
+    elif len(sys.argv) == 3 and sys.argv[1] == 'install' and os.path.join('AmberTools',
+            'src') in PYTRAJ_DIR:
+        # install pytraj in $AMBERHOME
+        # do not use pytraj_inside_amber here in we call `do_what()` before calling get_include_and_lib_dir()
         # don't mess this up
         # $(PYTHON) setup.py install $(PYTHON_INSTALL)
         do_install = True
@@ -210,8 +213,8 @@ def do_what():
         do_build = False
     return do_install, do_build
 
-cpptraj_dir, cpptraj_include, libdir, pytraj_inside_amber  = get_include_and_lib_dir()
 do_install, do_build = do_what()
+cpptraj_dir, cpptraj_include, libdir, pytraj_inside_amber  = get_include_and_lib_dir()
 
 # get *.pyx files
 pxd_include_dirs = [

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,11 @@ try:
 except ValueError:
     debug = False
 
+if len(sys.argv) == 2 and 'clean' in sys.argv:
+    do_clean = True
+else:
+    do_clean = False
+
 def read(fname):
     # must be in this setup file
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
@@ -205,8 +210,8 @@ def do_what():
         do_build = False
     return do_install, do_build
 
-do_install, do_build = do_what()
 cpptraj_dir, cpptraj_include, libdir, pytraj_inside_amber  = get_include_and_lib_dir()
+do_install, do_build = do_what()
 
 # get *.pyx files
 pxd_include_dirs = [
@@ -303,11 +308,12 @@ if debug:
 else:
     define_macros=[]
 
-cythonize(
-    [pfile + '.pyx' for pfile in pyxfiles],
-    nthreads=int(os.environ.get('NUM_THREADS', 4)),
-    compiler_directives=cython_directives,
-    )
+if not do_clean:
+    cythonize(
+        [pfile + '.pyx' for pfile in pyxfiles],
+        nthreads=int(os.environ.get('NUM_THREADS', 4)),
+        compiler_directives=cython_directives,
+        )
 
 ext_modules = []
 for ext_name in pyxfiles:

--- a/tests/test_ActionList.py
+++ b/tests/test_ActionList.py
@@ -391,6 +391,14 @@ class TestActionList(unittest.TestCase):
         t0 = traj[:8:2].autoimage().superpose()
         aa_eq(xyz, t0.xyz)
 
+        # from TrajectoryIterator, cpptraj's command style
+        fi = pt.create_pipeline(traj, '''
+        autoimage
+        rms''')
+        xyz = np.array([frame.xyz.copy() for frame in fi])
+        t0 = traj[:].autoimage().superpose()
+        aa_eq(xyz, t0.xyz)
+
     def test_reference(self):
         traj = pt.iterload("data/tz2.ortho.nc", "data/tz2.ortho.parm7")
 

--- a/tests/test_pmap.py
+++ b/tests/test_pmap.py
@@ -16,9 +16,6 @@ class TestNormalPmap(unittest.TestCase):
         self.traj = pt.iterload("./data/md1_prod.Tc5b.x", "./data/Tc5b.top")
 
     def test_raise(self):
-        # if func is not callable
-        self.assertRaises(ValueError, lambda: pt.pmap('test', self.traj))
-
         # if func is not support pmap
         self.assertRaises(ValueError, lambda: pt.pmap(pt.bfactors, self.traj))
 
@@ -151,6 +148,14 @@ class TestCpptrajCommandStyle(unittest.TestCase):
         distance_ = pt.distance(traj, '@10 @20')
 
         data = pt.pmap(['angle :3 :4 :5', 'distance @10 @20'], traj, n_cores=2)
+        assert isinstance(data, OrderedDict), 'must be OrderDict'
+        arr = pt.tools.dict_to_ndarray(data)
+        aa_eq(angle_, arr[0])
+        aa_eq(distance_, arr[1])
+
+        # as whole text, case 1
+        data = pt.pmap('''angle :3 :4 :5
+        distance @10 @20''', traj, n_cores=2)
         assert isinstance(data, OrderedDict), 'must be OrderDict'
         arr = pt.tools.dict_to_ndarray(data)
         aa_eq(angle_, arr[0])


### PR DESCRIPTION
cpptraj's commands as a single text

```python
data = pt.pmap('''angle :3 :4 :5
                  distance @10 @20''', traj, n_cores=2)
```

a list of cpptraj command (list of strings)
```python
data = pt.pmap(['angle :3 :4 :5',
                'distance @10 @20'], traj, n_cores=2)
```

should produce identical output.

Probably 1st case is good save my time when testing with ipython. But I prefer to have users to use 2nd case.