### PR TITLE
simplify pca calculation

### DIFF
--- a/pytraj/__init__.py
+++ b/pytraj/__init__.py
@@ -135,7 +135,7 @@ from .common_actions import (
     rotate_dihedral, make_structure, scale, clustering_dataset, randomize_ions,
     set_dihedral, crank, closest, search_neighbors, replicate_cell, _rotdif,
     calc_pairdist, _grid, transform, lowestcurve, calc_diffusion, calc_volmap,
-    calc_multivector)
+    calc_multivector, pca)
 
 from .matrix import dist
 distance_matrix = dist
@@ -210,6 +210,7 @@ pair_distribution = pairdist
 lowest_curve = lowestcurve
 diffusion = calc_diffusion
 volmap = calc_volmap
+calc_pca = pca
 
 adict = ActionDict()
 analdict = AnalysisDict()

--- a/pytraj/common_actions.py
+++ b/pytraj/common_actions.py
@@ -2718,13 +2718,13 @@ def pca(traj,
     >>> # compute pca for first and second modes
     >>> pca_data = pt.pca(traj, '!@H=', n_vecs=2)
     >>> # get projection values
-    >>> pca_data[0]
+    >>> pca_data[0] # doctest: +SKIP
     array([[  4.93425131,  13.80002308,  20.61605835, ..., -57.92280579,
             -61.25728607, -52.85142136],
            [  4.03333616,  -6.9132452 , -14.53991318, ...,  -6.757936  ,
               2.1086719 ,  -3.60922861]], dtype=float32)
     >>> # get eigenvalues for first 2 modes
-    >>> pca_data[1][0]
+    >>> pca_data[1][0] # doctest: +SKIP
     array([ 1399.36472919,   240.42342439])
 
     >>> # compute pca for all modes

--- a/pytraj/common_actions.py
+++ b/pytraj/common_actions.py
@@ -2689,7 +2689,14 @@ def pca(traj,
         n_vecs=2,
         dtype='ndarray',
         top=None):
-    '''perform PCA analysis
+    '''perform PCA analysis.
+
+    - perform rmsfit to first frame with ``mask``
+    - compute average frame with ``mask``
+    - rmsfit to average frame with ``mask``
+    - compute covariance matrix
+    - diagonalize the matrix to get eigenvectors and eigenvalues
+    - perform projection of each frame with mask to each eigenvector 
 
     Parameters
     ----------

--- a/pytraj/common_actions.py
+++ b/pytraj/common_actions.py
@@ -2660,7 +2660,8 @@ def _projection(traj,
     dslist.add_set('modes', mode_name)
     is_reduced = False
     dataset_mode = dslist[-1]
-    dataset_mode._set_modes(is_reduced, len(eigenvalues), eigenvectors.shape[1],
+    n_vectors = len(eigenvalues)
+    dataset_mode._set_modes(is_reduced, n_vectors, eigenvectors.shape[1],
                           eigenvalues, eigenvectors.flatten())
     dataset_mode.scalar_type = scalar_type
 
@@ -2669,7 +2670,8 @@ def _projection(traj,
 
     _mask = mask
     _evecs = 'evecs {}'.format(mode_name)
-    command = ' '.join((_evecs, _mask))
+    _beg_end = 'beg 1 end {}'.format(n_vectors)
+    command = ' '.join((_evecs, _mask, _beg_end))
     act(command, traj, top=top, dslist=dslist)
     dslist._pop(0)
     return _get_data_from_dtype(dslist, dtype=dtype)

--- a/pytraj/common_actions.py
+++ b/pytraj/common_actions.py
@@ -2720,6 +2720,7 @@ def pca(traj,
     Parameters
     ----------
     traj : Trajectory
+        traj must be ``pytraj.Trajectory``, which can be created by ``pytraj.load`` method.
     mask : str
         atom mask
     n_vecs : int, default 2
@@ -2734,6 +2735,26 @@ def pca(traj,
     -------
     projection_data: ndarray, shape=(n_vecs, n_frames)
     (eigenvalues, eigenvectors)
+
+    Examples
+    --------
+    >>> import pytraj as pt
+    >>> traj = pt.datafiles.load_tz2()[:]
+
+    >>> # compute pca for first and second modes
+    >>> pca_data = pt.pca(traj, '!@H=', n_vecs=2)
+    >>> # get projection values
+    >>> pca_data[0]
+    array([[  4.93425131,  13.80002308,  20.61605835, ..., -57.92280579,
+            -61.25728607, -52.85142136],
+           [  4.03333616,  -6.9132452 , -14.53991318, ...,  -6.757936  ,
+              2.1086719 ,  -3.60922861]], dtype=float32)
+    >>> # get eigenvalues for first 2 modes
+    >>> pca_data[1][0]
+    array([ 1399.36472919,   240.42342439])
+
+    >>> # compute pca for all modes
+    >>> pca_data = pt.pca(traj, '!@H=', n_vecs=-1)
     '''
     # TODO: move to another file
     from pytraj import matrix

--- a/pytraj/common_actions.py
+++ b/pytraj/common_actions.py
@@ -2257,7 +2257,7 @@ def timecorr(vec0,
              tcorr=10000.,
              norm=False,
              dtype='ndarray'):
-    """TODO: doc. not yet assert to cpptraj's output
+    """compute time correlation.
 
     Parameters
     ----------
@@ -2268,6 +2268,7 @@ def timecorr(vec0,
     tcorr : float, default 10000.
     norm : bool, default False
     """
+    # TODO: doc. not yet assert to cpptraj's output
     act = CpptrajAnalyses.Analysis_Timecorr()
 
     cdslist = CpptrajDatasetList()
@@ -2641,40 +2642,6 @@ def make_structure(traj=None, mask="", top=None):
     act(command, traj, top=_top)
 
 
-def _analyze_modes(data,
-                   mode='',
-                   beg=1,
-                   end=50,
-                   bose=False,
-                   factor=1.0,
-                   maskp=None,
-                   trajout='',
-                   pcmin=None,
-                   pcmax=None,
-                   tmode=None):
-    # TODO: not finished yet
-    '''Perform analysis on calculated Eigenmodes
-
-    Parameters
-    ----------
-    data :
-    mode : str, {'fluct', 'displ', 'corr', 'eigenval', 'trajout', 'rmsip'}
-        - fluct:    RMS fluctations from normal modes
-        - displ:    Displacement of cartesian coordinates along normal mode directions
-        - corr:     Calculate dipole-dipole correlation functions.
-        - eigenval: Calculate eigenvalue fractions.
-        - trajout:  Calculate pseudo-trajectory along given mode.
-        - rmsip:    Root mean square inner product.
-    beg : int
-    end : int
-    bose : bool, optional
-    factor : optional
-    maskp : a string or list of strings, optional
-    trajout : output filename, optional
-    '''
-    pass
-
-
 @_super_dispatch()
 def _projection(traj,
                 mask,
@@ -2708,11 +2675,16 @@ def _projection(traj,
     return _get_data_from_dtype(dslist, dtype=dtype)
 
 
-@_super_dispatch()
+@_super_dispatch(has_ref=True)
+def superpose(traj, ref=0, mask='', frame_indices=None, top=None): 
+    act = CpptrajActions.Action_Rmsd()
+    act(mask, traj, top=top)
+    return traj
+
+
 def pca(traj,
         mask,
         n_vecs=2,
-        frame_indices=None,
         dtype='ndarray',
         top=None):
     '''perform PCA analysis
@@ -2757,11 +2729,12 @@ def pca(traj,
     >>> pca_data = pt.pca(traj, '!@H=', n_vecs=-1)
     '''
     # TODO: move to another file
+    # NOTE: do not need to use _super_dispatch here since we already use in _projection
     from pytraj import matrix
 
-    traj.superpose(mask=mask, ref=0)
+    traj.superpose(ref=0, mask=mask)
     avg = mean_structure(traj)
-    traj.superpose(mask=mask, ref=avg)
+    traj.superpose(ref=avg, mask=mask)
     avg2 = mean_structure(traj, mask=mask)
 
     mat = matrix.covar(traj, mask)

--- a/pytraj/datasets/cpp_datasets.pxd
+++ b/pytraj/datasets/cpp_datasets.pxd
@@ -290,8 +290,7 @@ cdef extern from "DataSet_Modes.h":
         const Darray& AvgCrd() const 
         const Darray& Mass() const 
         int NavgCrd() const 
-        double * Avg_FramePtr() 
-        const double * Avg_FramePtr() const 
+        double * AvgFramePtr() 
         void AllocateAvgCoords(int n)
         void SetAvgCoords(const _Dataset2D&)
         int SetModes(bint, int, int, const double *, const double *)

--- a/pytraj/datasets/cpp_datasets.pyx
+++ b/pytraj/datasets/cpp_datasets.pyx
@@ -913,6 +913,18 @@ cdef class DatasetModes(Dataset):
             return np.array([ptr[i] for i in
                              range(n_modes*vsize)]).reshape(n_modes, vsize)
 
+    def _allocate_avgcoords(self, int n):
+        self.thisptr.AllocateAvgCoords(n)
+
+    def _set_avg_frame(self, double[:] arr):
+        cdef unsigned int i 
+        cdef double* ptr = self.thisptr.AvgFramePtr() 
+
+        for i in range(arr.shape[0]):
+            ptr[i] = arr[i]
+
+    def _get_avg_crd(self):
+        return self.thisptr.AvgCrd()
 
 cdef class DatasetMatrix3x3 (Dataset):
     def __cinit__(self):

--- a/tests/test_frame_indices.py
+++ b/tests/test_frame_indices.py
@@ -50,7 +50,7 @@ class TestFrameIndices(unittest.TestCase):
         excluded_fn = [calc_jcoupling, calc_volmap, calc_density,
                        energy_decomposition, center, search_neighbors,
                        calc_atomiccorr, autoimage, closest,
-                       calc_volume, ]
+                       calc_volume, superpose]
         func_nu = [
             calc_epsilon, calc_alpha, calc_zeta, calc_beta, calc_nu1, calc_nu2,
             calc_delta, calc_chin,

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -27,9 +27,9 @@ crdaction CRD1 projection evecs MyEvecs !@H= out project.dat beg 1 end 2
 '''
 
 
-class TestProject(unittest.TestCase):
+class TestPCA(unittest.TestCase):
 
-    def test_projection(self):
+    def test_pca(self):
         traj = pt.load("data/tz2.nc", "data/tz2.parm7")
 
         state = pt.load_cpptraj_state(command)

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -39,7 +39,8 @@ class TestPCA(unittest.TestCase):
 
         data = pt.pca(traj, mask, n_vecs=2)
         cpp_data = state.data[-2:].values
-        aa_eq(data[0], cpp_data)
+        # use absolute values
+        aa_eq(np.abs(data[0]), np.abs(cpp_data), decimal=3)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import unittest
+import numpy as np
+import pytraj as pt
+from pytraj.utils import eq, aa_eq
+
+command = '''
+# Step one. Generate average structure.
+# RMS-Fit to first frame to remove global translation/rotation.
+parm data/tz2.parm7
+trajin data/tz2.nc
+rms first !@H=
+average crdset AVG
+run
+# Step two. RMS-Fit to average structure. Calculate covariance matrix.
+# Save the fit coordinates.
+rms ref AVG !@H=
+matrix covar name MyMatrix !@H=
+createcrd CRD1
+run
+# Step three. Diagonalize matrix.
+runanalysis diagmatrix MyMatrix vecs 2 name MyEvecs
+# Step four. Project saved fit coordinates along eigenvectors 1 and 2
+crdaction CRD1 projection evecs MyEvecs !@H= out project.dat beg 1 end 2
+'''
+
+
+class TestProject(unittest.TestCase):
+
+    def test_projection(self):
+        traj = pt.load("data/tz2.nc", "data/tz2.parm7")
+
+        state = pt.load_cpptraj_state(command)
+        state.run()
+
+        mask = '!@H='
+
+        data = pt.pca(traj, mask, n_vecs=2)
+        cpp_data = state.data[-2:].values
+        aa_eq(data[0], cpp_data)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -27,7 +27,7 @@ crdaction CRD1 projection evecs MyEvecs !@H= out project.dat beg 1 end 2
 '''
 
 
-class TestProject(unittest.TestCase):
+class TestProjection(unittest.TestCase):
 
     def test_projection(self):
         traj = pt.load("./data/tz2.nc", "./data/tz2.parm7")

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import unittest
+import pytraj as pt
+from pytraj.utils import eq, aa_eq
+
+command = '''
+# Step one. Generate average structure.
+# RMS-Fit to first frame to remove global translation/rotation.
+parm tz2.parm7
+trajin tz2.nc
+rms first !@H=
+average crdset AVG
+run
+# Step two. RMS-Fit to average structure. Calculate covariance matrix.
+# Save the fit coordinates.
+rms ref AVG !@H=
+matrix covar name MyMatrix !@H=
+createcrd CRD1
+run
+# Step three. Diagonalize matrix.
+runanalysis diagmatrix MyMatrix vecs 2 name MyEvecs
+# Step four. Project saved fit coordinates along eigenvectors 1 and 2
+crdaction CRD1 projection evecs MyEvecs !@H= out project.dat beg 1 end 2
+'''
+
+
+class TestProject(unittest.TestCase):
+
+    def test_projection(self):
+        traj = pt.iterload("./data/tz2.nc", "./data/tz2.parm7")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -58,7 +58,7 @@ class TestProjection(unittest.TestCase):
                                                         eigenvalues=modes.eigenvalues, 
                                                         eigenvectors=modes.eigenvectors,
                                                         scalar_type='covar')
-        aa_eq(projection_data, state.data[-2:].values)
+        aa_eq(np.abs(projection_data), np.abs(state.data[-2:].values), decimal=3)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -51,8 +51,8 @@ class TestProjection(unittest.TestCase):
 
         aa_eq(cpp_arr_crd, avg2.xyz)
 
-        aa_eq(modes.eigenvalues, state.data['MyEvecs'].eigenvalues)
-        aa_eq(modes.eigenvectors, state.data['MyEvecs'].eigenvectors)
+        aa_eq(np.abs(modes.eigenvalues), np.abs(state.data['MyEvecs'].eigenvalues))
+        aa_eq(np.abs(modes.eigenvectors), np.abs(state.data['MyEvecs'].eigenvectors))
 
         projection_data = pt.common_actions._projection(traj, mask=mask, average_coords=avg2.xyz,
                                                         eigenvalues=modes.eigenvalues, 


### PR DESCRIPTION
Try to make pca in pytraj similiar to sklearn too?

current usage

```python
In [20]: pt.pca(traj, '@P', n_vecs=2)
Out[20]: 
(array([[ 10.36236763,  10.03283119,  14.62098026, ..., -10.45174313,
         -10.81758785, -12.98321533],
        [-11.02234077,  -8.2722187 ,  -6.74612713, ...,  -0.53519076,
          -3.8595717 ,  -2.75687122]], dtype=float32),
 (array([ 44.79219281,  32.29500218]),
  array([[-0.16254271,  0.11974073, -0.21648397, ..., -0.16616231,
           0.16027767, -0.09431382],
         [ 0.08633618,  0.15009632,  0.04454871, ...,  0.15871903,
           0.00325103, -0.16614721]])))
```

Tutorial: http://amber-md.github.io/pytraj/latest/tutorials/tut_pca.html