### PR TITLE
add reference to pca

### DIFF
--- a/pytraj/all_actions.py
+++ b/pytraj/all_actions.py
@@ -2579,7 +2579,7 @@ def pca(traj,
         top=None):
     '''perform PCA analysis by following below steps:
 
-    - perform rmsfit to first frame or ref (if provided) with ``mask``
+    - perform rmsfit to average structure or given reference (if provided) with ``mask``
     - compute average frame with ``mask``
     - rmsfit to average frame with ``mask``
     - compute covariance matrix
@@ -2596,7 +2596,8 @@ def pca(traj,
         number of eigenvectors. If user want to compute projection for all eigenvectors,
         should specify n_vecs=-1 (or a negative number)
     ref : {None, Frame, int}, default None
-        if None, fit to 1st frame else fit to given reference
+        if None, trajectory will be superposed to average structure
+        if is Frame or integer value, trajectory will be superposed to given reference
     dtype : return datatype
     top : Topology, optional
 

--- a/pytraj/all_actions.py
+++ b/pytraj/all_actions.py
@@ -2574,11 +2574,12 @@ def _projection(traj,
 def pca(traj,
         mask,
         n_vecs=2,
+        ref=None,
         dtype='ndarray',
         top=None):
     '''perform PCA analysis by following below steps:
 
-    - perform rmsfit to first frame with ``mask``
+    - perform rmsfit to first frame or ref (if provided) with ``mask``
     - compute average frame with ``mask``
     - rmsfit to average frame with ``mask``
     - compute covariance matrix
@@ -2594,6 +2595,8 @@ def pca(traj,
     n_vecs : int, default 2
         number of eigenvectors. If user want to compute projection for all eigenvectors,
         should specify n_vecs=-1 (or a negative number)
+    ref : {None, Frame, int}, default None
+        if None, fit to 1st frame else fit to given reference
     dtype : return datatype
     top : Topology, optional
 
@@ -2626,9 +2629,13 @@ def pca(traj,
     # NOTE: do not need to use super_dispatch here since we already use in _projection
     from pytraj import matrix
 
-    traj.superpose(ref=0, mask=mask)
-    avg = mean_structure(traj)
-    traj.superpose(ref=avg, mask=mask)
+    if ref is None:
+        traj.superpose(ref=0, mask=mask)
+        avg = mean_structure(traj)
+        traj.superpose(ref=avg, mask=mask)
+    else:
+        ref = get_reference(traj, ref)
+        traj.superpose(ref=ref, mask=mask)
     avg2 = mean_structure(traj, mask=mask)
 
     mat = matrix.covar(traj, mask)

--- a/pytraj/all_actions.py
+++ b/pytraj/all_actions.py
@@ -2579,9 +2579,8 @@ def pca(traj,
         top=None):
     '''perform PCA analysis by following below steps:
 
-    - perform rmsfit to average structure or given reference (if provided) with ``mask``
-    - compute average frame with ``mask``
-    - rmsfit to average frame with ``mask``
+    - perform rmsfit to average structure (but first doing rmsfit to 1st frame to remove rotation and translation)
+      or perform rmsfit to given reference (if provided) with ``mask``
     - compute covariance matrix
     - diagonalize the matrix to get eigenvectors and eigenvalues
     - perform projection of each frame with mask to each eigenvector

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -26,12 +26,28 @@ runanalysis diagmatrix MyMatrix vecs 2 name MyEvecs
 crdaction CRD1 projection evecs MyEvecs !@H= out project.dat beg 1 end 2
 '''
 
+command_ref_provided = '''
+parm data/tz2.parm7
+reference data/tz2.rst7
+trajin data/tz2.nc
+rms reference !@H=
+matrix covar name MyMatrix !@H=
+createcrd CRD1
+run
+# Step three. Diagonalize matrix.
+runanalysis diagmatrix MyMatrix vecs 2 name MyEvecs
+# Step four. Project saved fit coordinates along eigenvectors 1 and 2
+crdaction CRD1 projection evecs MyEvecs !@H= out project.dat beg 1 end 2
+'''
+
 
 class TestPCA(unittest.TestCase):
 
-    def test_pca(self):
+    def test_pca_noref(self):
+        '''no reference'''
         traj = pt.load("data/tz2.nc", "data/tz2.parm7")
 
+        # no reference
         state = pt.load_cpptraj_state(command)
         state.run()
 
@@ -41,6 +57,22 @@ class TestPCA(unittest.TestCase):
         cpp_data = state.data[-2:].values
         # use absolute values
         aa_eq(np.abs(data[0]), np.abs(cpp_data), decimal=3)
+
+    def test_pca_with_ref(self):
+        '''has reference'''
+        traj = pt.load("data/tz2.nc", "data/tz2.parm7")
+        ref = pt.load('data/tz2.rst7', traj.top)
+
+        state = pt.load_cpptraj_state(command_ref_provided)
+        state.run()
+
+        mask = '!@H='
+
+        data = pt.pca(traj, mask, n_vecs=2, ref=ref)
+        cpp_data = state.data[-2:].values
+        # use absolute values
+        aa_eq(np.abs(data[0]), np.abs(cpp_data), decimal=3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
https://github.com/Amber-MD/pytraj/issues/1112

```python
traj = pt.load("data/tz2.nc", "data/tz2.parm7")
ref = pt.load('data/tz2.rst7', traj.top)
mask = '!@H='
pt.pca(traj, mask, n_vecs=2, ref=ref)
```

is equal to
```bash
parm data/tz2.parm7
reference data/tz2.rst7
trajin data/tz2.nc
rms reference !@H=
matrix covar name MyMatrix !@H=
createcrd CRD1
run
# Step three. Diagonalize matrix.
runanalysis diagmatrix MyMatrix vecs 2 name MyEvecs
# Step four. Project saved fit coordinates along eigenvectors 1 and 2
crdaction CRD1 projection evecs MyEvecs !@H= out project.dat beg 1 end 2
```