### PR TITLE
lazy superpose

### DIFF
--- a/pytraj/c_traj/c_trajectory.pxd
+++ b/pytraj/c_traj/c_trajectory.pxd
@@ -28,3 +28,5 @@ cdef class TrajectoryCpptraj:
     cdef list _filelist
     cdef public _base
     cdef public bint _own_memory
+    cdef public bint _is_superposed
+    cdef public dict _ref_dict # used

--- a/pytraj/c_traj/c_trajectory.pyx
+++ b/pytraj/c_traj/c_trajectory.pyx
@@ -130,7 +130,7 @@ cdef class TrajectoryCpptraj:
         Notes
         -----
         This method is different from ``superpose`` in pytraj.Trajectory.
-        It does not change the cooridates of TrajectoryCpptraj/TrajectoryIterator itself but 
+        It does not change the coordinates of TrajectoryCpptraj/TrajectoryIterator itself but 
         the copy of Frame.
         """
         cdef AtomMask atm = self.top(mask)

--- a/pytraj/trajectory_iterator.py
+++ b/pytraj/trajectory_iterator.py
@@ -449,7 +449,7 @@ class TrajectoryIterator(TrajectoryCpptraj):
         -----
         This method is different from ``superpose`` in pytraj.Trajectory.
         It does not change the coordinates of TrajectoryCpptraj/TrajectoryIterator itself but 
-        the copy of Frame.
+        changing the coordinates of copied Frame.
 
         This method is mainly for NGLView in Jupyter notebook, to view out-of-core data.
         It's good to do translation and rotation on the fly.

--- a/pytraj/trajectory_iterator.py
+++ b/pytraj/trajectory_iterator.py
@@ -448,10 +448,10 @@ class TrajectoryIterator(TrajectoryCpptraj):
         Notes
         -----
         This method is different from ``superpose`` in pytraj.Trajectory.
-        It does not change the cooridates of TrajectoryCpptraj/TrajectoryIterator itself but 
+        It does not change the coordinates of TrajectoryCpptraj/TrajectoryIterator itself but 
         the copy of Frame.
 
-        This method is mainly for used with NGLView in Jupyter notebook, to view out-of-core data.
+        This method is mainly for NGLView in Jupyter notebook, to view out-of-core data.
         It's good to do translation and rotation on the fly.
 
 

--- a/pytraj/trajectory_iterator.py
+++ b/pytraj/trajectory_iterator.py
@@ -16,6 +16,7 @@ from .frameiter import FrameIterator
 from .get_common_objects import _load_Topology
 from .utils import split_range
 from .utils.convert import array_to_cpptraj_atommask
+from pytraj.get_common_objects import  get_reference
 
 __all__ = ['TrajectoryIterator', ]
 
@@ -439,6 +440,50 @@ class TrajectoryIterator(TrajectoryCpptraj):
         (10, 5293, 3)
         '''
         return (self.n_frames, self.n_atoms, 3)
+
+    def superpose(self, ref=None, mask='*'):
+        """register to superpose to reference frame when iterating. 
+        To turn off superposing, set traj._is_superposed = False
+
+        Notes
+        -----
+        This method is different from ``superpose`` in pytraj.Trajectory.
+        It does not change the cooridates of TrajectoryCpptraj/TrajectoryIterator itself but 
+        the copy of Frame.
+
+        This method is mainly for used with NGLView in Jupyter notebook, to view out-of-core data.
+        It's good to do translation and rotation on the fly.
+
+
+        Examples
+        --------
+        >>> import pytraj as pt
+        >>> traj = pt.datafiles.load_tz2()
+        >>> isinstance(traj, pt.TrajectoryIterator)
+        True
+        >>> traj[0].xyz[0]
+        array([-1.88900006,  9.1590004 ,  7.56899977])
+
+        >>> # turn on superpose
+        >>> traj.superpose(ref=-1, mask='@CA')
+        >>> traj[0].xyz[0]
+        array([ 6.97324167,  8.82901548,  1.31844696])
+
+        >>> # turn off superpose
+        >>> traj._is_superposed = False
+        >>> traj[0].xyz[0]
+        array([-1.88900006,  9.1590004 ,  7.56899977])
+
+        Example for NGLView::
+
+            import pytraj as pt, nglview as nv
+            traj = pt.datafiles.load_tz2()
+            traj.superpose(ref=0, mask='@CA')
+            view = nv.show_pytraj(traj)
+            view
+        """
+        ref = get_reference(self, ref)
+        super(TrajectoryIterator, self).superpose(ref=ref, mask=mask)
 
     def _split_iterators(self,
                          n_chunks=1,

--- a/tests/test_superpose.py
+++ b/tests/test_superpose.py
@@ -5,7 +5,9 @@ from pytraj import adict
 from pytraj.testing import aa_eq
 
 
-class TestBasic(unittest.TestCase):
+class TestSuperposeTrajectory(unittest.TestCase):
+    """superpose mutable Trajectory
+    """
 
     def test_frame_fit(self):
         traj = pt.iterload("./data/Tc5b.x", "./data/Tc5b.top")
@@ -124,6 +126,20 @@ class TestBasic(unittest.TestCase):
         pt.rmsd(t0, ref=traj[0], mask='@CA')
         pt.superpose(t1, ref=traj[0], mask='@CA')
         aa_eq(t0.xyz, t1.xyz)
+
+class TestSuperposeTrajectoryIterator(unittest.TestCase):
+    """test superpose TrajectoryIterator
+    """
+
+    def test_superpose_trajectory_iterator(self):
+        traj_immut= pt.iterload("data/Tc5b.x", "data/Tc5b.top")
+        traj_mut = pt.load("data/Tc5b.x", "data/Tc5b.top")
+
+        ref = pt.iterload("data/Tc5b.crd", "data/Tc5b.top")[0]
+        traj_mut.superpose(ref=ref, mask='@CA')
+        traj_immut.superpose(ref=ref, mask='@CA')
+        
+        aa_eq(traj_mut.xyz, traj_immut.xyz)
 
 
 if __name__ == "__main__":

--- a/tests/test_superpose.py
+++ b/tests/test_superpose.py
@@ -133,7 +133,8 @@ class TestSuperposeTrajectoryIterator(unittest.TestCase):
     """
 
     def test_superpose_trajectory_iterator(self):
-        traj_immut= pt.iterload("data/Tc5b.x", "data/Tc5b.top")
+        traj_immut = pt.iterload("data/Tc5b.x", "data/Tc5b.top")
+        traj_immut2 = pt.iterload("data/Tc5b.x", "data/Tc5b.top")
         traj_mut = pt.load("data/Tc5b.x", "data/Tc5b.top")
 
         ref = pt.iterload("data/Tc5b.crd", "data/Tc5b.top")[0]
@@ -149,6 +150,10 @@ class TestSuperposeTrajectoryIterator(unittest.TestCase):
 
             aa_eq(pt.load('t0.nc', traj_mut.top).xyz,
                   pt.load('t1.nc', traj_immut.top).xyz)
+
+        # turn off superpose
+        traj_immut._is_superposed = False
+        aa_eq(traj_immut.xyz, traj_immut2.xyz)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_superpose.py
+++ b/tests/test_superpose.py
@@ -3,6 +3,7 @@ import unittest
 import pytraj as pt
 from pytraj import adict
 from pytraj.testing import aa_eq
+from pytraj.utils import tempfolder
 
 
 class TestSuperposeTrajectory(unittest.TestCase):
@@ -141,6 +142,13 @@ class TestSuperposeTrajectoryIterator(unittest.TestCase):
         
         aa_eq(traj_mut.xyz, traj_immut.xyz)
 
+        # test saving
+        with tempfolder():
+            traj_mut.save('t0.nc')
+            traj_immut.save('t1.nc')
+
+            aa_eq(pt.load('t0.nc', traj_mut.top).xyz,
+                  pt.load('t1.nc', traj_immut.top).xyz)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_template_for_doc.py
+++ b/tests/test_template_for_doc.py
@@ -25,7 +25,7 @@ class TestDoc(unittest.TestCase):
     '''
 
     def test_doc(self):
-        modules = [pt.all_actions, ]
+        modules = [pt.trajectory_iterator, ]
         if PY3:
             assert get_total_errors(
                 modules) == 0, 'doctest: failed_count must be 0'


### PR DESCRIPTION
This method is mainly for NGLView in Jupyter notebook, to view out-of-core data.
It's good to do translation and rotation on the fly.

```python
            import pytraj as pt
            import  nglview as nv
            traj = pt.iterload('big_traj.nc', 'big_top.parm7')
            traj.superpose(ref=0, mask='@CA')
            view = nv.show_pytraj(traj)
```



