### PR TITLE
fix slicing when using lazy transformation

### DIFF
--- a/pytraj/c_traj/c_trajectory.pyx
+++ b/pytraj/c_traj/c_trajectory.pyx
@@ -444,6 +444,8 @@ cdef class TrajectoryCpptraj:
                 frame.thisptr.SetXptr(frame.n_atoms, &xyz[j, 0, 0])
                 # copy coordinates of `self[i]` to j-th frame in `traj`
                 self.thisptr.GetFrame(i, frame.thisptr[0])
+                if self._being_transformed:
+                    self._actionlist.compute(frame)
                 traj.unitcells[j] = frame.box._get_data()
             return traj
 
@@ -456,6 +458,8 @@ cdef class TrajectoryCpptraj:
                 # dump coords to xyz array
                 # copy coordinates of `self[i]` to j-th frame in `traj`
                 self.thisptr.GetFrame(i, frame.thisptr[0])
+                if self._being_transformed:
+                    self._actionlist.compute(frame)
                 traj.xyz[j] = frame.xyz
                 traj.unitcells[j] = frame.box._get_data()
             return traj
@@ -470,6 +474,8 @@ cdef class TrajectoryCpptraj:
         for i in frame_indices:
             assert 0 <= i < max_frame, 'frame index must be between 0 and max_frame - 1'
             self.thisptr.GetFrame(i, frame.thisptr[0])
+            if self._being_transformed:
+                self._actionlist.compute(frame)
             yield frame
 
     def translate(self, command):

--- a/tests/test_actionlist_trajectoryiterator.py
+++ b/tests/test_actionlist_trajectoryiterator.py
@@ -80,5 +80,21 @@ class TestActionList(unittest.TestCase):
 
         nt.assert_equal(len(traj_on_disk._cdslist), 0)
 
+    def test_autoimage_and_slicing(self):
+        traj_on_disk = pt.datafiles.load_tz2_ortho()
+        traj_on_mem = traj_on_disk[:]
+        aa_eq(traj_on_disk.xyz, traj_on_mem.xyz)
+
+        aa_eq(traj_on_disk.autoimage().xyz, traj_on_mem.autoimage().xyz)
+
+        aa_eq(traj_on_mem[:1].xyz, traj_on_disk[:1].xyz)
+        aa_eq(traj_on_mem[:].xyz, traj_on_disk[:].xyz)
+
+        from pytraj.externals.six import zip
+
+        for f0, f1 in zip(traj_on_disk(0, 8, 2), traj_on_mem(0, 8, 2)):
+            aa_eq(f0.xyz, f1.xyz)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
issue

```python
traj = pt.iterload(...)
traj.autoimage()
traj[:1] # autoimage is not updated.
```

this PR fix that.

Related: https://github.com/arose/nglview/pull/168