### PR TITLE
fix alignment/rmsd when using reference with different atom number

### DIFF
--- a/pytraj/all_actions.py
+++ b/pytraj/all_actions.py
@@ -2434,8 +2434,8 @@ def native_contacts(traj=None,
     command_ = " ".join(('ref myframe', command, _distance, _noimage,
                          _includesolvent, _byres))
     c_dslist.add('ref_frame', 'myframe')
-    c_dslist[0].add_frame(ref)
     c_dslist[0].top = top
+    c_dslist[0].add_frame(ref)
     act(command_, traj, top=top, dslist=c_dslist)
     c_dslist._pop(0)
 

--- a/pytraj/datasets/c_datasets.pyx
+++ b/pytraj/datasets/c_datasets.pyx
@@ -1123,6 +1123,8 @@ cdef class DatasetCoords(Dataset):
             self.baseptr_1.CoordsSetup(other.thisptr[0], self.baseptr_1.CoordsInfo())
 
     def add_frame(self, Frame frame):
+        if self.top.n_atoms != frame.n_atoms:
+            raise ValueError("Frame and Topology must have the same number of atoms")
         self.baseptr_1.AddFrame(frame.thisptr[0])
 
     def append(self, frame):

--- a/pytraj/get_common_objects.py
+++ b/pytraj/get_common_objects.py
@@ -146,21 +146,26 @@ def get_reference(traj, ref):
     '''
     if isinstance(ref, integer_types):
         try:
-            return traj[ref]
+            ref_ = traj[ref]
+            ref_.top = traj.top
         except TypeError:
             raise TypeError("%s does not support indexing" % str(traj))
     elif ref is None:
         try:
-            return traj[0]
+            ref_ = traj[0]
+            ref_.top = traj.top
         except TypeError:
             raise TypeError(
                 "If reference is an integer, %s must support indexing" %
                 traj.__str__())
     elif 'Trajectory' in ref.__class__.__name__:
         assert ref.n_frames == 1, "only support 1-frame Trajectory as reference"
-        return ref[0]
+        ref_ = ref[0]
+        ref_.top = ref.top
     else:
-        return ref
+        ref_ = ref
+
+    return ref_
 
 
 def get_fiterator(traj, frame_indices=None):

--- a/run_tests.py
+++ b/run_tests.py
@@ -75,6 +75,8 @@ if need_help:
 print("start testing. Go to ./tests folder")
 os.chdir("./tests/")
 
+import pytraj as pt; print(pt)
+
 if do_simple_test:
     os.system("python ./run_simple_test.py")
     print('\nHAPPY COMPUTING')

--- a/tests/test_actionlist.py
+++ b/tests/test_actionlist.py
@@ -219,6 +219,7 @@ class TestActionList(unittest.TestCase):
         actlist = ActionList(commands, traj.top, dslist=dslist)
 
         d0 = dslist.add('ref_frame', 'my_ref')
+        d0.top = traj.top
         d0.add_frame(traj[3])
 
         for frame in traj:

--- a/tests/test_superpose.py
+++ b/tests/test_superpose.py
@@ -174,7 +174,6 @@ class TestSuperposeTrajectoryIterator(unittest.TestCase):
         traj_on_disk._being_transformed = False
         aa_eq(traj_on_disk.xyz, traj_on_disk2.xyz)
 
-    @unittest.skip("know failure")
     def test_superpose_different_mask_with_mass(self):
         traj_on_disk = pt.iterload("data/Tc5b.x", "data/Tc5b.top")
         traj_on_mem = pt.load("data/Tc5b.x", "data/Tc5b.top")
@@ -184,9 +183,7 @@ class TestSuperposeTrajectoryIterator(unittest.TestCase):
         mask = ':3-12@CA'
         ref_mask = ':1-10@CA'
 
-        pt._verbose()
         traj_on_disk.superpose(mask=mask, ref=ref, ref_mask=ref_mask)
-        pt._verbose(False)
         traj_on_mem.superpose(mask=mask, ref=ref, ref_mask=ref_mask)
 
         aa_eq(traj_on_disk.xyz, traj_on_mem.xyz)
@@ -216,14 +213,12 @@ class TestSuperposeTrajectoryIterator(unittest.TestCase):
         """.format(mask=mask, refmask=ref_mask)
 
         state2 = pt.load_cpptraj_state(cm2)
-        pt._verbose()
         state2.run()
-        pt._verbose(False)
 
         aa_eq(state.data['mycrd'].xyz, state2.data['mycrd'].xyz)
 
-        # aa_eq(state.data['mycrd'].xyz, traj_on_disk.xyz)
-        # aa_eq(state.data['mycrd'].xyz, traj_on_mem.xyz)
+        aa_eq(state.data['mycrd'].xyz, traj_on_disk.xyz)
+        aa_eq(state.data['mycrd'].xyz, traj_on_mem.xyz)
 
 class TestAlign(unittest.TestCase):
 


### PR DESCRIPTION
The source of error is that cpptraj's DataSet_Coords does not do checking n_atoms (topology vs frame) when adding new Frame.

`pytraj` force Frame must have the same n_atoms as Topology.

```python
    def add_frame(self, Frame frame):
        if self.top.n_atoms != frame.n_atoms:
            raise ValueError("Frame and Topology must have the same number of atoms")
        self.baseptr_1.AddFrame(frame.thisptr[0])
```
