### PR TITLE
example: using cpptraj style + add `PrintActions` for ActionList

### DIFF
--- a/examples/example_cpptraj_style.py
+++ b/examples/example_cpptraj_style.py
@@ -1,0 +1,23 @@
+import pytraj as pt
+
+refname  = '../tests/data/Tc5b.nat.inpcrd'
+fn = '../tests/data/Tc5b.x'
+prmtop  = '../tests/data/Tc5b.prmtop'
+
+traj = pt.iterload(fn, top=prmtop)
+ref = pt.iterload(refname, top=prmtop)
+
+cm = """
+rms reference @CA
+distance :3 :7
+angle :3 :8 :12
+multidihedral phi psi
+molsurf @CA
+atomicfluct
+"""
+
+# need to specify ref=ref
+# TODO: reflist
+data = pt.compute(cm, traj, ref=ref)
+
+print(data)

--- a/examples/example_cpptraj_style.py
+++ b/examples/example_cpptraj_style.py
@@ -13,7 +13,6 @@ distance :3 :7
 angle :3 :8 :12
 multidihedral phi psi
 molsurf @CA
-atomicfluct
 """
 
 # need to specify ref=ref

--- a/pytraj/c_action/actionlist.pxd
+++ b/pytraj/c_action/actionlist.pxd
@@ -20,7 +20,7 @@ cdef extern from "ActionList.h":
                       _ActionInit&,)
         int SetupActions(_ActionSetup, bint exit_on_error)
         bint DoActions(int, _ActionFrame)
-        void Print()
+        void PrintActions()
         void List()
         bint Empty()
         int Naction()

--- a/pytraj/c_action/actionlist.pyx
+++ b/pytraj/c_action/actionlist.pyx
@@ -346,7 +346,5 @@ cdef class ActionList:
             for frame in iterframe_master(traj):
                 self.compute(frame)
 
-        self.post_process()
-
     def post_process(self):
         self.thisptr.PrintActions()

--- a/pytraj/c_action/actionlist.pyx
+++ b/pytraj/c_action/actionlist.pyx
@@ -345,3 +345,8 @@ cdef class ActionList:
         else:
             for frame in iterframe_master(traj):
                 self.compute(frame)
+
+        self.post_process()
+
+    def post_process(self):
+        self.thisptr.PrintActions()


### PR DESCRIPTION
uhm, this makes customizing a group of commands easier

```python
def compute_method(traj, ...):
    cm = """
    # write your cpptraj commands here
    """
    return pytraj.compute(cm, traj, *args, **kwd)
```

ack. I should think about this earlier.