### PR TITLE
ADD support write_data (xmgrace, gnu, ...)

### DIFF
--- a/pytraj/io.py
+++ b/pytraj/io.py
@@ -830,8 +830,6 @@ def write_data(filename, data):
     d0 = state.data.add(dtype=dtype, name=dataset_name)
     d0.data = np.asarray(data)
 
-    print(d0, d0.values)
-
     cm = 'writedata {filename} {dataset_name}'.format(filename=filename, dataset_name=dataset_name)
 
     with Command() as command:

--- a/pytraj/io.py
+++ b/pytraj/io.py
@@ -792,10 +792,50 @@ def read_data(filename, options=''):
     cdslist.read_data(filename, options)
     return cdslist
 
-def write_data(filename):
-    """same as writedata in cpptraj
+def write_data(filename, data):
+    """same as writedata in cpptraj. (this is work in progress, only support 1D-array for now)
+
+    Parameters
+    ----------
+    filename : str
+        output filename. File format is deteced by its name.
+    data : ndarray
+    dtype : str, {'double', 'float', 'grid_float', 'grid_double'}, default 'double'
+
+    Examples
+    --------
+    >>> # xmgrace format
+    >>> import pytraj as pt
+    >>> traj = pt.datafiles.load_tz2()
+    >>> rmsd_data = pt.rmsd(traj, ref=0)
+    >>> pt.io.write_data('my.agr', rmsd_data)
+
+    >>> # gnu format
+    >>> pt.io.write_data('my.gnu', rmsd_data)
     """
-    raise NotImplementedError()
+    data = np.asarray(data, dtype='f8')
+
+    dtype_map = {1: 'double',
+                 3: 'grid_float'}
+
+    from pytraj.core.c_core import CpptrajState, Command
+
+    dtype = dtype_map[data.ndim]
+
+    if data.ndim == 3:
+        data = data.astype('f4')
+
+    state = CpptrajState()
+    dataset_name = 'my_data'
+    d0 = state.data.add(dtype=dtype, name=dataset_name)
+    d0.data = np.asarray(data)
+
+    print(d0, d0.values)
+
+    cm = 'writedata {filename} {dataset_name}'.format(filename=filename, dataset_name=dataset_name)
+
+    with Command() as command:
+        command.dispatch(state, cm)
 
 def _get_amberhome():
     amberhome = os.getenv('AMBERHOME')

--- a/tests/test_write_data.py
+++ b/tests/test_write_data.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import os
+import unittest
+import numpy as np
+import pytraj as pt
+from pytraj.utils import eq, aa_eq
+
+
+class TestWriteData(unittest.TestCase):
+
+    def test_write_data(self):
+        traj = pt.iterload("data/tz2.ortho.nc", "data/tz2.ortho.parm7")
+        rmsd_data = pt.rmsd(traj)
+
+        try:
+            os.remove("test.agr")
+            os.remove("test.gnu")
+            os.remove("test.dx")
+        except OSError:
+            pass
+
+        pt.io.write_data("test.agr", rmsd_data)
+        pt.io.write_data("test.gnu", rmsd_data)
+
+        assert os.path.exists("test.agr")
+        assert os.path.exists("test.gnu")
+
+        # not supported yet
+        # data_3d = pt.gist(traj, options='name gist')['gist[gO]']
+        # pt.io.write_data("test.dx", data_3d)
+        # assert os.path.exists("test.dx")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
only support 1D array for now. Still having this #1280 issue.

```python
rmsd_data = pt.rmsd(traj, ref=0)
pt.io.write_data('my.agr', rmsd_data)
```