### PR TITLE
ensure pytraj reproduce elec energy

### DIFF
--- a/pytraj/analysis/energy_analysis.py
+++ b/pytraj/analysis/energy_analysis.py
@@ -175,6 +175,11 @@ def esander(traj=None,
     if top.has_box():
         box = top.box.tolist()
         has_box = True
+        # try to use 1st frame's box
+        try:
+            box = traj[0].box.tolist()
+        except IndexError:
+            pass
     else:
         box = None
         has_box = False

--- a/pytraj/analysis/energy_analysis.py
+++ b/pytraj/analysis/energy_analysis.py
@@ -178,7 +178,7 @@ def esander(traj=None,
         # try to use 1st frame's box
         try:
             box = traj[0].box.tolist()
-        except IndexError:
+        except (IndexError, TypeError):
             pass
     else:
         box = None

--- a/tests/energies/test_sander_energies.py
+++ b/tests/energies/test_sander_energies.py
@@ -158,7 +158,7 @@ class TestSander(unittest.TestCase):
         assert_close(edict['bond'][0], 605.7349, tol=3E-4)
         assert_close(edict['vdw_14'][0], 0.0000, tol=3E-4)
         assert_close(edict['elec_14'][0], 0.0000, tol=3E-4)
-        assert_close(edict['elec'][0], -7409.7167, tol=3E-1)
+        assert_close(edict['elec'][0], -7409.7167, tol=3E-4)
         assert_close(edict['scf'][0], -37.1277, tol=3E-4)
 
     @unittest.skipIf(not amberhome, 'skip since there is no AMBERHOME')


### PR DESCRIPTION
try Niel's files:
```python
import sander
import pytraj as pt
import parmed as pmd
# make default pme input
inp = sander.pme_input()
# update to your files
parm_file = 'prmtop'
rst7_file = 'inpcrd'
parm = pmd.load_file(parm_file, rst7_file)

with sander.setup(parm_file, parm.coordinates, parm.box, mm_options=inp):
    e, f = sander.energy_forces()
    print('from pysander: ',e.elec)

traj = pt.iterload(rst7_file, parm_file)
ene = pt.esander(traj, mm_options=sander.pme_input())
print('from pytraj: ', ene['elec'][0])
```

output
```bash
from pysander:  -8225.698560432662
from pytraj:  -8225.69856043
```