### PR TITLE
change makestructure reference syntax

### DIFF
--- a/pytraj/all_actions.py
+++ b/pytraj/all_actions.py
@@ -1397,8 +1397,8 @@ def get_velocity(traj, mask=None, frame_indices=None):
     frame_indices : iterable that produces integer, default None, optional
         if not None, only get velocity for given frame indices
 
-    Return
-    ------
+    Returns
+    -------
     out : 3D numpy array, shape (n_frames, n_atoms, 3)
 
     Examples
@@ -3345,8 +3345,8 @@ def lowestcurve(data, points=10, step=0.2):
     points : number of lowest points in each bin, default 10
     step : step size, default 0.2
 
-    Return
-    ------
+    Returns
+    -------
     2d array
     '''
     points_ = 'points ' + str(points)

--- a/pytraj/builder/build.py
+++ b/pytraj/builder/build.py
@@ -50,21 +50,31 @@ def make_structure(traj, command="", ref=None):
 
     Notes
     -----
-    cpptraj doc
-
     Apply dihedrals to specified residues using arguments found in <List of Args>,
     where an argument is 1 or more of the following arg types:
-      '<sstype>:<res range>' Apply SS type (phi/psi) to residue range.
-          <sstype> standard = alpha, left, pp2, hairpin, extended
-          <sstype> turn = typeI, typeII, typeVIII, typeI', typeII,
-                          typeVIa1, typeVIa2, typeVIb
-          Turns are applied to 2 residues at a time, so resrange must be divisible by 4.
-      '<custom ss>:<res range>:<phi>:<psi>' Apply custom <phi>/<psi> to residue range.
-      '<custom turn>:<res range>:<phi1>:<psi1>:<phi2>:<psi2>' Apply custom turn <phi>/<psi> pair to residue range.
-      '<custom dih>:<res range>:<dih type>:<angle>' Apply <angle> to dihedrals in range.
-          <dih type> = alpha beta gamma delta epsilon zeta nu1 nu2 h1p c2p chin phi psi chip omega
-      '<custom dih>:<res range>:<at0>:<at1>:<at2>:<at3>:<angle>[:<offset>]'
+
+    r'<sstype>:<res range>'
+        Apply SS type (phi/psi) to residue range.
+
+        <sstype> standard = alpha, left, pp2, hairpin, extended
+
+        <sstype> turn = typeI, typeII, typeVIII, typeI', typeII, typeVIa1, typeVIa2, typeVIb
+            Turns are applied to 2 residues at a time, so resrange must be divisible by 4.
+
+    r'<custom ss>:<res range>:<phi>:<psi>'
+        Apply custom <phi>/<psi> to residue range.
+
+    '<custom turn>:<res range>:<phi1>:<psi1>:<phi2>:<psi2>'
+        Apply custom turn <phi>/<psi> pair to residue range.
+
+    '<custom dih>:<res range>:<dih type>:<angle>'
+        Apply <angle> to dihedrals in range.
+
+        <dih type> = alpha beta gamma delta epsilon zeta nu1 nu2 h1p c2p chin phi psi chip omega
+
+    '<custom dih>:<res range>:<at0>:<at1>:<at2>:<at3>:<angle>[:<offset>]'
           Apply <angle> to dihedral defined by atoms <at1>, <at2>, <at3>, and <at4>.
+
           Offset -2=<a0><a1> in previous res, -1=<a0> in previous res,
                   0=All <aX> in single res,
                   1=<a3> in next res, 2=<a2><a3> in next res.

--- a/pytraj/builder/build.py
+++ b/pytraj/builder/build.py
@@ -16,9 +16,10 @@ def make_structure(traj, command="", ref=None):
     ref : None or a Frame or a Trajectory with one Frame
         if not None, use `ref` as reference. If ref.top is None, use `traj.top`, else use ref.top
 
-        If ref is given, the reference name must be 'myref' (which is different from cpptraj usage).
+        If `ref` is given, the `command` should be command = 'ref:<range>:<ref range>'.
+        Please note that this syntax is different from cpptraj, you do not need to provide
+        reference name.
         If ref is a Trajectory having more than 1 frame, only first frame is considered.
-        This API is unstable.
       
     Returns
     -------
@@ -42,32 +43,31 @@ def make_structure(traj, command="", ref=None):
     ...     trajin_rst7 = pp2.rst7.save'
     ...     traj = pt.load(trajin_rst7, top=tz2_parm7)
     ...     ref = pt.load(ref_rst7, top=tz2_parm7)
-    ...     # must use "myref" for reference name
-    ...     pt.make_structure(traj, "ref:1-13:myref", ref=ref)
+    ...     # make dihedral angle for targeted residues 1 to 13 by using
+    ...     # reference residues 1 to 13
+    ...     pt.make_structure(traj, "ref:1-13:1-13", ref=ref)
 
 
     Notes
     -----
-    cpptraj doc::
+    cpptraj doc
 
-        <List of Args>
-      Apply dihedrals to specified residues using arguments found in <List of Args>,
-      where an argument is 1 or more of the following arg types:
-        '<sstype>:<res range>' Apply SS type (phi/psi) to residue range.
-            <sstype> standard = alpha, left, pp2, hairpin, extended
-            <sstype> turn = typeI, typeII, typeVIII, typeI', typeII,
-                            typeVIa1, typeVIa2, typeVIb
-            Turns are applied to 2 residues at a time, so resrange must be divisible by 4.
-        '<custom ss>:<res range>:<phi>:<psi>' Apply custom <phi>/<psi> to residue range.
-        '<custom turn>:<res range>:<phi1>:<psi1>:<phi2>:<psi2>' Apply custom turn <phi>/<psi> pair to residue range.
-        '<custom dih>:<res range>:<dih type>:<angle>' Apply <angle> to dihedrals in range.
-            <dih type> = alpha beta gamma delta epsilon zeta nu1 nu2 h1p c2p chin phi psi chip omega
-        '<custom dih>:<res range>:<at0>:<at1>:<at2>:<at3>:<angle>[:<offset>]' Apply <angle> to dihedral defined by atoms <at1>, <at2>, <at3>, and <at4>.
-            Offset -2=<a0><a1> in previous res, -1=<a0> in previous res,
-                    0=All <aX> in single res,
-                    1=<a3> in next res, 2=<a2><a3> in next res.
-        'ref:<range>:<refname>[:<ref range>]' Apply dihedrals from reference <refname>.
-
+    Apply dihedrals to specified residues using arguments found in <List of Args>,
+    where an argument is 1 or more of the following arg types:
+      '<sstype>:<res range>' Apply SS type (phi/psi) to residue range.
+          <sstype> standard = alpha, left, pp2, hairpin, extended
+          <sstype> turn = typeI, typeII, typeVIII, typeI', typeII,
+                          typeVIa1, typeVIa2, typeVIb
+          Turns are applied to 2 residues at a time, so resrange must be divisible by 4.
+      '<custom ss>:<res range>:<phi>:<psi>' Apply custom <phi>/<psi> to residue range.
+      '<custom turn>:<res range>:<phi1>:<psi1>:<phi2>:<psi2>' Apply custom turn <phi>/<psi> pair to residue range.
+      '<custom dih>:<res range>:<dih type>:<angle>' Apply <angle> to dihedrals in range.
+          <dih type> = alpha beta gamma delta epsilon zeta nu1 nu2 h1p c2p chin phi psi chip omega
+      '<custom dih>:<res range>:<at0>:<at1>:<at2>:<at3>:<angle>[:<offset>]'
+          Apply <angle> to dihedral defined by atoms <at1>, <at2>, <at3>, and <at4>.
+          Offset -2=<a0><a1> in previous res, -1=<a0> in previous res,
+                  0=All <aX> in single res,
+                  1=<a3> in next res, 2=<a2><a3> in next res.
     """
     assert isinstance(command, list) or isinstance(command, string_types), 'command must be a string or a list of string'
     assert isinstance(traj, Trajectory), 'traj must be a Trajectory object'
@@ -76,11 +76,15 @@ def make_structure(traj, command="", ref=None):
 
     if ref is not None:
         ref_name = 'myref'
-        for cm in cmlist:
+        for index, cm in enumerate(cmlist):
             if cm.startswith('ref'):
-                assert cm.split(':')[2] == ref_name, 'must give ref_name of "myref"'
+                tokens = cm.split(':')
+                assert len(tokens) == 3, 'command must follow format ref:<range>:<ref range>'
+                # insert ref_name
+                cm_ = ':'.join(tokens[:2] + [ref_name] + tokens[-1:])
+                cmlist[index] = cm_
         c_dslist = CpptrajDatasetList()
-        frame_dset = c_dslist.add('reference', name='myref')
+        frame_dset = c_dslist.add('reference', name=ref_name)
         frame_dset.top = ref.top if ref.top is not None else traj.top
         ref_ = ref if isinstance(ref, Frame) else ref[0]
         frame_dset.append(ref_)

--- a/pytraj/builder/build.py
+++ b/pytraj/builder/build.py
@@ -36,6 +36,15 @@ def make_structure(traj, command="", ref=None):
     >>> # Make hairpin for residue 1 to 5 and make alpha helix for residue 6 to 12
     >>> traj = pt.make_structure(traj, ["hairpin:1-5", "alpha:6-12"])
 
+    >>> # From cpptraj example:
+    >>> # Make residues 1 and 12 ’extended’, residues 6 and 7 a type I’ turn, and two
+    >>> # custom assignments, one (custom1) for residues 2-5, the other (custom2) for residues 8-11:
+    >>> traj = pt.make_structure(traj, ["extended:1,12",
+    ...                                 "custom1:2-5:-80.:130.:-130.:140.",
+    ...                                 "typeI':6-7",
+    ...                                 "custom2:8-11:-140.:170.:-100.:140."])
+    >>>
+
     >>> # Make new structure from reference
     >>> def make_new_by_using_ref(): # doctest: +SKIP
     ...     tz2_parm7 = 'tz2.parm7'

--- a/pytraj/builder/build.py
+++ b/pytraj/builder/build.py
@@ -53,7 +53,8 @@ def make_structure(traj, command="", ref=None):
     Apply dihedrals to specified residues using arguments found in <List of Args>,
     where an argument is 1 or more of the following arg types:
 
-    r'<sstype>:<res range>'
+    '<sstype>:<res range>'
+
         Apply SS type (phi/psi) to residue range.
 
         <sstype> standard = alpha, left, pp2, hairpin, extended
@@ -61,18 +62,22 @@ def make_structure(traj, command="", ref=None):
         <sstype> turn = typeI, typeII, typeVIII, typeI', typeII, typeVIa1, typeVIa2, typeVIb
             Turns are applied to 2 residues at a time, so resrange must be divisible by 4.
 
-    r'<custom ss>:<res range>:<phi>:<psi>'
+    '<custom ss>:<res range>:<phi>:<psi>'
+
         Apply custom <phi>/<psi> to residue range.
 
     '<custom turn>:<res range>:<phi1>:<psi1>:<phi2>:<psi2>'
+
         Apply custom turn <phi>/<psi> pair to residue range.
 
     '<custom dih>:<res range>:<dih type>:<angle>'
+
         Apply <angle> to dihedrals in range.
 
         <dih type> = alpha beta gamma delta epsilon zeta nu1 nu2 h1p c2p chin phi psi chip omega
 
     '<custom dih>:<res range>:<at0>:<at1>:<at2>:<at3>:<angle>[:<offset>]'
+
           Apply <angle> to dihedral defined by atoms <at1>, <at2>, <at3>, and <at4>.
 
           Offset -2=<a0><a1> in previous res, -1=<a0> in previous res,

--- a/pytraj/trajectory/trajectory_iterator.py
+++ b/pytraj/trajectory/trajectory_iterator.py
@@ -471,7 +471,7 @@ class TrajectoryIterator(TrajectoryCpptraj, SharedTrajectory):
         >>> traj[0].xyz[0]
         array([-1.88900006,  9.1590004 ,  7.56899977])
 
-        Example for NGLView::
+        Examples for NGLView::
 
             import pytraj as pt, nglview as nv
             traj = pt.datafiles.load_tz2()

--- a/pytraj/utils/check_and_assert.py
+++ b/pytraj/utils/check_and_assert.py
@@ -146,7 +146,8 @@ def _import(modname):
 def has_(lib):
     """check if having `lib` library
 
-    Example:
+    Examples
+    --------
     >>> has_np = has_("numpy")
     """
     return _import(lib)[0]

--- a/scripts/base_setup.py
+++ b/scripts/base_setup.py
@@ -94,7 +94,7 @@ disable openmp install in pytraj by adding --disable-openmp
 Note: For osx users, pytraj uses clang for compiling cython extension and '--disable-openmp' flag
 must be specified. If experienced users want to hack, please check setup.py file.
 
-Example:
+Examples:
     - Turn off openmp in pytraj: python setup.py install --disable-openmp
     - Turn ON openmp in cpptraj: ./configure -shared -openmp gnu && make libcpptraj -j4
     - Turn ON openmp in cpptraj and using netcdf, lapack, ... in $AMBERHOME (if having

--- a/tests/test_make_structure.py
+++ b/tests/test_make_structure.py
@@ -49,7 +49,7 @@ class TestMakeStructure(unittest.TestCase):
         # pytraj
         traj = pt.load(trajin_rst7, top=tz2_parm7)
         ref = pt.load(ref_rst7, top=tz2_parm7)
-        pt.make_structure(traj, "ref:1-13:myref", ref=ref)
+        pt.make_structure(traj, "ref:1-13:1-13", ref=ref)
         pt.rmsd(traj, ref=ref)
         aa_eq(traj.xyz, cpp_traj.xyz)
 


### PR DESCRIPTION
```bash
pt.make_structure(traj, command='ref:1-13:1-13', ref=ref)
```

Excluding reference name since we explicitly passing the `ref`