### PR TITLE
Fix some tests (correct path)

### DIFF
--- a/tests/test_analysis/test_center_of_mass.py
+++ b/tests/test_analysis/test_center_of_mass.py
@@ -18,7 +18,7 @@ class Test(unittest.TestCase):
         for frame in traj:
             pass
 
-        saved_d0 = np.loadtxt("./data/vec.out", skiprows=1, usecols=(1, 2, 3))
+        saved_d0 = np.loadtxt(fn('vec.out'), skiprows=1, usecols=(1, 2, 3))
 
         aa_eq(d1.to_ndarray().flatten(), saved_d0.flatten())
         aa_eq(d2.to_ndarray().flatten(), saved_d0.flatten())

--- a/tests/test_analysis/test_check_chirality.py
+++ b/tests/test_analysis/test_check_chirality.py
@@ -8,11 +8,9 @@ from pytraj.testing import cpptraj_test_dir, aa_eq
 cpptraj_test_dir + '/tz2.parm7'
 bad_pdb = cpptraj_test_dir + '/Test_CheckStructure/tz2.stretched.pdb'
 
-cm = """
-parm data/DPDP.parm7
-trajin data/DPDP.nc
-checkchirality
-"""
+parm_name = fn('DPDP.parm7')
+traj_name = fn('DPDP.nc')
+cm = "parm " + parm_name + "\ntrajin " + traj_name + "\ncheckchirality\n"
 
 def test_check_structure():
     traj = pt.iterload(fn('DPDP.nc'), fn('DPDP.parm7'))

--- a/tests/test_analysis/test_closest.py
+++ b/tests/test_analysis/test_closest.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import pytraj as pt
-from utils import fn
+from utils import fn, outputname
 from pytraj.utils import aa_eq
 
 
@@ -32,9 +32,9 @@ class TestClosest(unittest.TestCase):
         # test write to disk
         fi, top = pt.closest(traj)
 
-        pt.write_traj('output/fi.nc', fi, top=top, overwrite=True)
+        pt.write_traj(outputname('fi.nc'), fi, top=top, overwrite=True)
         # load back
-        t1 = pt.load('output/fi.nc', top=top)
+        t1 = pt.load(outputname('fi.nc'), top=top)
         aa_eq(t0.xyz, t1.xyz)
 
         # make sure n_sovent=10 (default)
@@ -45,7 +45,7 @@ class TestClosest(unittest.TestCase):
         assert n_solvents == 10, 'must be 10 solvents'
 
         fi, top = pt.closest(traj)
-        pt.write_traj('output/test.pdb', next(fi), top=top, overwrite=True)
+        pt.write_traj(outputname('test.pdb'), next(fi), top=top, overwrite=True)
 
     def test_closest_compared_to_cpptraj(self):
         traj = pt.iterload(fn('tz2.ortho.nc'), fn('tz2.ortho.parm7'))

--- a/tests/test_analysis/test_dihedral_analysis.py
+++ b/tests/test_analysis/test_dihedral_analysis.py
@@ -14,7 +14,7 @@ class Test(unittest.TestCase):
         traj = pt.iterload(fn('Tc5b.x'), fn('Tc5b.top'))
 
         # resrange 7, phi psi
-        saved_file = './data/test_multidihedral.dat'
+        saved_file = fn('test_multidihedral.dat')
         saved_data_phi = np.loadtxt(saved_file, skiprows=1).transpose()[1]
 
         arr0 = da.calc_phi(traj, resrange='7').to_ndarray()

--- a/tests/test_analysis/test_distance.py
+++ b/tests/test_analysis/test_distance.py
@@ -64,8 +64,8 @@ class TestNormalDistance(unittest.TestCase):
     def test_distance_with_dry_traj_and_PBC_topology(self):
         '''Situation: there is dry traj (no box) but Topology has box info
         '''
-        traj = pt.iterload('data/dry_traj_with_PBC_top/strip.nc',
-                           'data/dry_traj_with_PBC_top/strip.prmtop')
+        traj = pt.iterload(fn('dry_traj_with_PBC_top/strip.nc'),
+                           fn('dry_traj_with_PBC_top/strip.prmtop'))
         assert traj.top.has_box(), 'Topology must have box for testing'
 
         correct_distance_with_image_True = pt.distance(traj,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,10 @@ def fn(name):
     # return absolute dir of ./data/name
     return os.path.join(os.path.dirname(__file__), 'data', name)
 
+def outputname(name):
+    # return absolute dir of ./output/name
+    return os.path.join(os.path.dirname(__file__), 'output', name)
+
 tc5b_trajin = fn('Tc5b.x')
 tc5b_top = fn('Tc5b.top')
 tz2_trajin  = fn('tz2.nc')


### PR DESCRIPTION
This fixes some tests where the input file names were using absolute paths instead of the `fn()` function from `utils.py`. Also adds a function `outputname()` to `utils.py` to fix output file paths, which fixes `test_closest.py`. 