### PR TITLE
ENH: slice on-dist trajectory with velocity will give a on-mem trajectory with velocity

### DIFF
--- a/pytraj/trajectory/c_traj/c_trajectory.pyx
+++ b/pytraj/trajectory/c_traj/c_trajectory.pyx
@@ -451,6 +451,7 @@ cdef class TrajectoryCpptraj:
             return traj
 
         else:
+            traj.velocities = np.zeros((n_frames, n_atoms, 3), dtype='f8')
             # slower
             frame = Frame()
             frame.thisptr[0] = self.thisptr.AllocateFrame()
@@ -463,6 +464,7 @@ cdef class TrajectoryCpptraj:
                     self._do_transformation(frame)
                 traj.xyz[j] = frame.xyz
                 traj.unitcells[j] = frame.box._get_data()
+                traj.velocities[j] = frame.velocity
             return traj
 
     def _iterframe_indices(self, frame_indices):

--- a/tests/test_analysis/test_velocity.py
+++ b/tests/test_analysis/test_velocity.py
@@ -88,9 +88,6 @@ class TestVelocity(unittest.TestCase):
         # need to raise if no `velocity_arr` is given
         traj_on_mem = traj[:]
 
-        with pytest.raises(ValueError):
-            pt.all_actions.velocityautocorr(
-                traj_on_mem, tstep=2, norm=True, direct=True, usevelocity=True)
         # try on memory Trajectory, usevelocity = True
         traj_on_disk = traj
         velocity_arr = pt.get_velocity(traj_on_disk)

--- a/tests/test_trajectory/test_fancy_indexing.py
+++ b/tests/test_trajectory/test_fancy_indexing.py
@@ -35,7 +35,6 @@ class TestSlicingTrajectory(unittest.TestCase):
         traj = pt.iterload(
             fn('issue807/trunc.nc'), fn("issue807/system.prmtop"))
 
-        mem_traj = traj[:]
         aa_eq(pt.get_velocity(traj),
               pt.get_velocity(traj[:]))
 

--- a/tests/test_trajectory/test_fancy_indexing.py
+++ b/tests/test_trajectory/test_fancy_indexing.py
@@ -31,6 +31,17 @@ class TestSlicingTrajectory(unittest.TestCase):
         aa_eq(fa4[1].xyz, traj[2].xyz)
         aa_eq(fa4[0].xyz, traj[1].xyz)
 
+    def test_velocity(self):
+        traj = pt.iterload(
+            fn('issue807/trunc.nc'), fn("issue807/system.prmtop"))
+
+        mem_traj = traj[:]
+        aa_eq(pt.get_velocity(traj),
+              pt.get_velocity(traj[:]))
+
+        aa_eq(pt.get_velocity(traj, frame_indices=[1, 3, 5]),
+              pt.get_velocity(traj[[1, 3, 5]]))
+
     def test_atommask(self):
         # AtomMask
         traj = pt.iterload(fn('Tc5b.x'), fn('Tc5b.top'))
@@ -45,49 +56,43 @@ class TestSlicingTrajectory(unittest.TestCase):
         aa_eq(traj[0, atm, 0], xyz[0][indices][0])
 
 
-class Test1(unittest.TestCase):
-    def test_0(self):
-        # create Trajectory from Trajing_Single
-        traj = pt.iterload(fn('Tc5b.x'), fn('Tc5b.top'))[:]
-        aa_eq(traj[3, 3], traj[3][3, :])
-        frame1 = traj[1]
-        aa_eq(frame1[0], traj[1][:, :][0])
-        assert traj[0, 0, 0] == -16.492
-        assert traj[:, :, 0][0, 0] == traj[0, 0, 0]
-        traj[0]
-        farr0 = traj[:2]
+def test_slice_from_Trajin_Single():
+    # create Trajectory from Trajing_Single
+    traj = pt.iterload(fn('Tc5b.x'), fn('Tc5b.top'))[:]
+    aa_eq(traj[3, 3], traj[3][3, :])
+    frame1 = traj[1]
+    aa_eq(frame1[0], traj[1][:, :][0])
+    assert traj[0, 0, 0] == -16.492
+    assert traj[:, :, 0][0, 0] == traj[0, 0, 0]
+    traj[0]
+    farr0 = traj[:2]
 
-        fa = traj[2:4]
+    fa = traj[2:4]
 
-        # we don't support traj[:, idx] or traj[:, idx, idy] since this give wrong answer
-        #  got ~0.0 value
-        aa_eq(traj[:, 0, 0], np.asarray(traj[0][0]))
+    # we don't support traj[:, idx] or traj[:, idx, idy] since this give wrong answer
+    #  got ~0.0 value
+    aa_eq(traj[:, 0, 0], np.asarray(traj[0][0]))
 
-        for i in range(traj[0]._buffer2d.shape[0]):
-            aa_eq(traj[:, :, 0][i], traj[0]._buffer2d[i])
+    for i in range(traj[0]._buffer2d.shape[0]):
+        aa_eq(traj[:, :, 0][i], traj[0]._buffer2d[i])
 
-        # slicing with mask
-        atm = traj.top("@CA")
-        traj[atm]
-        traj[:, atm]
-
-
-class TestSegmentationFault(unittest.TestCase):
-    def test_0(self):
-        # NOTE: no assert, just check for segfault
-        traj = pt.load(fn('Tc5b.x'), fn('Tc5b.top'))
-        pt.load(fn('Tc5b.x'), fn('Tc5b.top'))
-        traj.top("@CA")
-        f0 = traj[5]
-        f0 = traj[0]
-        f0.top = traj.top
-        f0['@CA']
-        traj[0, '@CA']
-
-        f0 = traj[0, '@CA']
-        f1 = traj['@CA'][0]
-        assert pt.tools.rmsd(f0.xyz, f1.xyz) == 0.0
+    # slicing with mask
+    atm = traj.top("@CA")
+    traj[atm]
+    traj[:, atm]
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_segmentation_fault():
+    # NOTE: no assert, just check for segfault
+    traj = pt.load(fn('Tc5b.x'), fn('Tc5b.top'))
+    pt.load(fn('Tc5b.x'), fn('Tc5b.top'))
+    traj.top("@CA")
+    f0 = traj[5]
+    f0 = traj[0]
+    f0.top = traj.top
+    f0['@CA']
+    traj[0, '@CA']
+
+    f0 = traj[0, '@CA']
+    f1 = traj['@CA'][0]
+    assert pt.tools.rmsd(f0.xyz, f1.xyz) == 0.0


### PR DESCRIPTION
- Code example

```python
    def test_velocity(self):
        traj = pt.iterload(
            fn('issue807/trunc.nc'), fn("issue807/system.prmtop"))

        aa_eq(pt.get_velocity(traj),
              pt.get_velocity(traj[:]))

        aa_eq(pt.get_velocity(traj, frame_indices=[1, 3, 5]),
              pt.get_velocity(traj[[1, 3, 5]]))
```

- Also (gradually) adapt pytest style