### PR TITLE
Add CMake build system changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,58 @@
+#CMake buildfile for the pytraj wrapper for cpptraj
+project(pytraj)
+
+
+#figure out arguments
+
+if(OPENMP)
+	set(OPENMP_ARG "")
+else()
+	set(OPENMP_ARG --disable-openmp)
+endif()
+
+#------------------------------------------------------------------------------------------
+
+set(BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/python-build)
+set(STAMP_FILE ${BUILD_DIR}/pytraj-build.stamp)
+set(LIBDIR_FILE ${BUILD_DIR}/libcpptraj.location)
+
+file(MAKE_DIRECTORY ${BUILD_DIR})
+#find all python library files as dependencies
+file(GLOB_RECURSE PYTHON_SOURCES "*.py" "*.pyx" "*.pxd")
+
+#we use cmake -E env to manipulate the environment of setup.py
+
+add_custom_command(OUTPUT ${STAMP_FILE}
+	COMMAND ${CMAKE_COMMAND} -E env --unset=AMBERHOME 
+		CPPTRAJ_HEADERDIR=${CMAKE_CURRENT_SOURCE_DIR}/../cpptraj/src CPPTRAJ_LIBDIR=$<TARGET_FILE_DIR:libcpptraj>
+		CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
+		${PYTHON_EXECUTABLE} setup.py build_ext --no-setuptools -b ${BUILD_DIR} ${OPENMP_ARG} ${PYTHON_COMPILER_ARG} ${WIN64_DEFINE_ARG}
+	COMMAND ${CMAKE_COMMAND} -E touch ${STAMP_FILE}
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	DEPENDS ${PYTHON_SOURCES} libcpptraj
+	VERBATIM
+	COMMENT "Building pytraj native library")
+
+#We want to build the python library during the build step so as to catch any build errors
+add_custom_target(pytraj ALL DEPENDS ${STAMP_FILE} SOURCES ${PYTHON_SOURCES})
+
+#you can't put a generator expression into an install SCRIPT rule, which I need to do.
+#waiting on https://gitlab.kitware.com/cmake/cmake/issues/15785
+get_property(LIBCPPTRAJ_INCDIR TARGET libcpptraj PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+
+file(GENERATE OUTPUT ${LIBDIR_FILE} CONTENT "
+	#this file contains the real location of libcpptraj, which is a Special Thing in CMake.  It is read by the install script.
+	set(CPPTRAJ_LIBDIR $<TARGET_FILE_DIR:libcpptraj>)")
+
+install(CODE "
+	include(${LIBDIR_FILE})
+	${FIX_BACKSLASHES_CMD}
+	execute_process(
+    COMMAND \"${CMAKE_COMMAND}\" -E env  --unset=AMBERHOME
+    \"CPPTRAJ_HEADERDIR=${CMAKE_CURRENT_SOURCE_DIR}/../cpptraj/src\" \"CPPTRAJ_LIBDIR=\${CPPTRAJ_LIBDIR}\"
+    \"CXX=${CMAKE_CXX_COMPILER}\"
+    \"CC=${CMAKE_C_COMPILER}\"
+	${PYTHON_EXECUTABLE}
+  	./setup.py build_ext --no-setuptools -b \"${BUILD_DIR}\" ${OPENMP_ARG} ${PYTHON_COMPILER_ARG} ${WIN64_DEFINE_ARG} install ${PYTHON_PREFIX_ARG}
+    WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\")")
+	

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-#CMake buildfile for the pytraj wrapper for cpptraj
+# AmberTools CMake buildfile for the pytraj wrapper for cpptraj
+# NOTE: This is NOT a standalone build file
+# It is used by the Amber build system for when it builds pytraj
+# If you are just trying to build pytraj, run setup.py, not this!
+
 project(pytraj)
 
 

--- a/scripts/base_setup.py
+++ b/scripts/base_setup.py
@@ -288,7 +288,7 @@ def get_cpptraj_info(rootname, cpptraj_home, cpptraj_included,
         AMBERHOME = os.getenv('AMBERHOME', '')
         AMBER_PREFIX = os.getenv('AMBER_PREFIX', '')
         
-        #if the paths were not manually specified (as by the CMake buildsystem), try to get them from AMBERHOME
+        # if the paths were not manually specified (as by the CMake buildsystem), try to get them from AMBERHOME
         if not (CPPTRAJ_LIBDIR and CPPTRAJ_HEADERDIR):
             if not AMBERHOME:
                 raise EnvironmentError(

--- a/scripts/base_setup.py
+++ b/scripts/base_setup.py
@@ -287,17 +287,20 @@ def get_cpptraj_info(rootname, cpptraj_home, cpptraj_included,
         # install pytraj inside AMBER
         AMBERHOME = os.getenv('AMBERHOME', '')
         AMBER_PREFIX = os.getenv('AMBER_PREFIX', '')
-        if not AMBERHOME:
-            raise EnvironmentError(
-                'must set AMBERHOME if you want to install pytraj '
-                'inside AMBER')
-        # overwrite CPPTRAJ_HEADERDIR, CPPTRAJ_LIBDIR
-        if AMBER_PREFIX:
-            CPPTRAJ_LIBDIR = os.path.join(AMBER_PREFIX, 'lib')
-        else:
-            CPPTRAJ_LIBDIR = os.path.join(AMBERHOME, 'lib')
-        CPPTRAJ_HEADERDIR = os.path.join(AMBERHOME, 'AmberTools', 'src',
-                                         'cpptraj', 'src')
+        
+        #if the paths were not manually specified (as by the CMake buildsystem), try to get them from AMBERHOME
+        if not (CPPTRAJ_LIBDIR and CPPTRAJ_HEADERDIR):
+            if not AMBERHOME:
+                raise EnvironmentError(
+                    'must set AMBERHOME if you want to install pytraj '
+                    'inside AMBER')
+            # overwrite CPPTRAJ_HEADERDIR, CPPTRAJ_LIBDIR
+            if AMBER_PREFIX:
+                CPPTRAJ_LIBDIR = os.path.join(AMBER_PREFIX, 'lib')
+            else:
+                CPPTRAJ_LIBDIR = os.path.join(AMBERHOME, 'lib')
+            CPPTRAJ_HEADERDIR = os.path.join(AMBERHOME, 'AmberTools', 'src',
+                                             'cpptraj', 'src')
 
         cpptraj_info.ambertools_distro = True
     else:


### PR DESCRIPTION
The CMake build system requires some changes to pytraj.  In CMake, the location of compiled files is decided by CMake, and is not guaranteed to be consistent.   So, you can't just use the Amber lib directory.  You *almost* had the right setup for CMake to pass in the locations via `CPPTRAJ_LIBDIR` and `CPPTRAJ_HEADERDIR`; I just had to edit `base_setup.py` so that it will use those variables when they are provided even if pytraj is being built inside Amber.

Also, I designed the CMake build system to not modify the source directory at all so as to make using Git easier, and I found the `build -b <dir>` argument to Distutils to relocate the Python built files.  However, there doesn't seem to be any way to tell Cython not to put its generated files in the source directory, at least from the command line.  Do you know if it's possible to change the Cython build directory?

Another issue I was having was the MinGW compiler throwing errors about being unable to export symbols with names corresponding to each Python file.  It [looks like](https://stackoverflow.com/questions/34689210/error-exporting-symbol-when-building-python-c-extension-in-windows) Distutils expects each Python C extension to define some sort of initialization function.  Currently, the only way to build pytraj on Windows is to screw with your Python installation: in `<python install dir>/Lib/distutils/cygwinccompiler.py`, change line 193 to `if (False and`.  I've set up the CMake system's Miniconda installer to apply this patch automatically, but it would be nice if you could create these functions so we could get away from this hack.

Finally, if you were wondering, here's a sample of the command that CMake uses to build Pytraj on Windows:
```
env --unset=AMBERHOME CPPTRAJ_HEADERDIR=<path to cpptraj headers> CPPTRAJ_LIBDIR=<directory containing libcpptraj> CC=<cmake c compiler> CXX=<cmake cxx compiler> python setup.py build_ext --no-setuptools -b <path to build dir> --disable-openmp -compiler=mingw32 -DMS_WIN64
```