### PR TITLE
Add one more thing for CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,58 @@
+#CMake buildfile for the pytraj wrapper for cpptraj
+project(pytraj)
+
+
+#figure out arguments
+
+if(OPENMP)
+	set(OPENMP_ARG "")
+else()
+	set(OPENMP_ARG --disable-openmp)
+endif()
+
+#------------------------------------------------------------------------------------------
+
+set(BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/python-build)
+set(STAMP_FILE ${BUILD_DIR}/pytraj-build.stamp)
+set(LIBDIR_FILE ${BUILD_DIR}/libcpptraj.location)
+
+file(MAKE_DIRECTORY ${BUILD_DIR})
+#find all python library files as dependencies
+file(GLOB_RECURSE PYTHON_SOURCES "*.py" "*.pyx" "*.pxd")
+
+#we use cmake -E env to manipulate the environment of setup.py
+
+add_custom_command(OUTPUT ${STAMP_FILE}
+	COMMAND ${CMAKE_COMMAND} -E env --unset=AMBERHOME 
+		CPPTRAJ_HEADERDIR=${CMAKE_CURRENT_SOURCE_DIR}/../cpptraj/src CPPTRAJ_LIBDIR=$<TARGET_FILE_DIR:libcpptraj>
+		CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
+		${PYTHON_EXECUTABLE} setup.py build_ext --no-setuptools -b ${BUILD_DIR} ${OPENMP_ARG} ${PYTHON_COMPILER_ARG} ${WIN64_DEFINE_ARG}
+	COMMAND ${CMAKE_COMMAND} -E touch ${STAMP_FILE}
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	DEPENDS ${PYTHON_SOURCES} libcpptraj
+	VERBATIM
+	COMMENT "Building pytraj native library")
+
+#We want to build the python library during the build step so as to catch any build errors
+add_custom_target(pytraj ALL DEPENDS ${STAMP_FILE} SOURCES ${PYTHON_SOURCES})
+
+#you can't put a generator expression into an install SCRIPT rule, which I need to do.
+#waiting on https://gitlab.kitware.com/cmake/cmake/issues/15785
+get_property(LIBCPPTRAJ_INCDIR TARGET libcpptraj PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+
+file(GENERATE OUTPUT ${LIBDIR_FILE} CONTENT "
+	#this file contains the real location of libcpptraj, which is a Special Thing in CMake.  It is read by the install script.
+	set(CPPTRAJ_LIBDIR $<TARGET_FILE_DIR:libcpptraj>)")
+
+install(CODE "
+	include(${LIBDIR_FILE})
+	${FIX_BACKSLASHES_CMD}
+	execute_process(
+    COMMAND \"${CMAKE_COMMAND}\" -E env  --unset=AMBERHOME
+    \"CPPTRAJ_HEADERDIR=${CMAKE_CURRENT_SOURCE_DIR}/../cpptraj/src\" \"CPPTRAJ_LIBDIR=\${CPPTRAJ_LIBDIR}\"
+    \"CXX=${CMAKE_CXX_COMPILER}\"
+    \"CC=${CMAKE_C_COMPILER}\"
+	${PYTHON_EXECUTABLE}
+  	./setup.py build_ext --no-setuptools -b \"${BUILD_DIR}\" ${OPENMP_ARG} ${PYTHON_COMPILER_ARG} ${WIN64_DEFINE_ARG} install ${PYTHON_PREFIX_ARG}
+    WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\")")
+	

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-#CMake buildfile for the pytraj wrapper for cpptraj
+# AmberTools CMake buildfile for the pytraj wrapper for cpptraj
+# NOTE: This is NOT a standalone build file
+# It is used by the Amber build system for when it builds pytraj
+# If you are just trying to build pytraj, run setup.py, not this!
+
 project(pytraj)
 
 

--- a/devtools/ci/setup_env.sh
+++ b/devtools/ci/setup_env.sh
@@ -14,14 +14,14 @@ fi
 bash miniconda.sh -b
 
 export PATH=$HOME/miniconda3/bin:$PATH
-conda install --yes conda-build jinja2 anaconda-client pip cython=0.25 numpy
+conda install --yes conda-build jinja2 anaconda-client pip numpy
 pip install auditwheel
 
 # create myenv
 conda create -y -n myenv python=$PYTHON_VERSION
 source activate myenv
 conda update -y conda
-conda install -y numpy cython h5py libnetcdf pyflakes
+conda install -y numpy cython=0.25 5py libnetcdf pyflakes
 conda install -y hdf4 # temporary install to fix error "libmfhdf.so.0: cannot open shared object file"
 pip install auditwheel
 

--- a/devtools/ci/setup_env.sh
+++ b/devtools/ci/setup_env.sh
@@ -14,7 +14,7 @@ fi
 bash miniconda.sh -b
 
 export PATH=$HOME/miniconda3/bin:$PATH
-conda install --yes conda-build jinja2 anaconda-client pip numpy
+conda install --yes conda-build jinja2 anaconda-client pip numpy cython=0.25
 pip install auditwheel
 
 # create myenv

--- a/devtools/ci/setup_env.sh
+++ b/devtools/ci/setup_env.sh
@@ -21,7 +21,7 @@ pip install auditwheel
 conda create -y -n myenv python=$PYTHON_VERSION
 source activate myenv
 conda update -y conda
-conda install -y numpy cython=0.25 5py libnetcdf pyflakes
+conda install -y numpy cython=0.25 h5py libnetcdf pyflakes
 conda install -y hdf4 # temporary install to fix error "libmfhdf.so.0: cannot open shared object file"
 pip install auditwheel
 

--- a/devtools/ci/setup_env.sh
+++ b/devtools/ci/setup_env.sh
@@ -14,7 +14,7 @@ fi
 bash miniconda.sh -b
 
 export PATH=$HOME/miniconda3/bin:$PATH
-conda install --yes conda-build jinja2 anaconda-client pip cython numpy
+conda install --yes conda-build jinja2 anaconda-client pip cython=0.25 numpy
 pip install auditwheel
 
 # create myenv

--- a/scripts/base_setup.py
+++ b/scripts/base_setup.py
@@ -288,7 +288,7 @@ def get_cpptraj_info(rootname, cpptraj_home, cpptraj_included,
         AMBERHOME = os.getenv('AMBERHOME', '')
         AMBER_PREFIX = os.getenv('AMBER_PREFIX', '')
         
-        #if the paths were not manually specified (as by the CMake buildsystem), try to get them from AMBERHOME
+        # if the paths were not manually specified (as by the CMake buildsystem), try to get them from AMBERHOME
         if not (CPPTRAJ_LIBDIR and CPPTRAJ_HEADERDIR):
             if not AMBERHOME:
                 raise EnvironmentError(

--- a/scripts/base_setup.py
+++ b/scripts/base_setup.py
@@ -390,7 +390,7 @@ def setenv_cc_cxx(ambertools_distro, extra_compile_args, extra_link_args):
                         CXX = line.split('=', 1)[-1]
                         break
         else:
-            #detect environment variables passed from CMake script
+            # detect environment variables passed from CMake script
             CC = os.environ.get('CC')
             CXX = os.environ.get('CXX')
             if CC and CXX:

--- a/scripts/base_setup.py
+++ b/scripts/base_setup.py
@@ -287,17 +287,20 @@ def get_cpptraj_info(rootname, cpptraj_home, cpptraj_included,
         # install pytraj inside AMBER
         AMBERHOME = os.getenv('AMBERHOME', '')
         AMBER_PREFIX = os.getenv('AMBER_PREFIX', '')
-        if not AMBERHOME:
-            raise EnvironmentError(
-                'must set AMBERHOME if you want to install pytraj '
-                'inside AMBER')
-        # overwrite CPPTRAJ_HEADERDIR, CPPTRAJ_LIBDIR
-        if AMBER_PREFIX:
-            CPPTRAJ_LIBDIR = os.path.join(AMBER_PREFIX, 'lib')
-        else:
-            CPPTRAJ_LIBDIR = os.path.join(AMBERHOME, 'lib')
-        CPPTRAJ_HEADERDIR = os.path.join(AMBERHOME, 'AmberTools', 'src',
-                                         'cpptraj', 'src')
+        
+        #if the paths were not manually specified (as by the CMake buildsystem), try to get them from AMBERHOME
+        if not (CPPTRAJ_LIBDIR and CPPTRAJ_HEADERDIR):
+            if not AMBERHOME:
+                raise EnvironmentError(
+                    'must set AMBERHOME if you want to install pytraj '
+                    'inside AMBER')
+            # overwrite CPPTRAJ_HEADERDIR, CPPTRAJ_LIBDIR
+            if AMBER_PREFIX:
+                CPPTRAJ_LIBDIR = os.path.join(AMBER_PREFIX, 'lib')
+            else:
+                CPPTRAJ_LIBDIR = os.path.join(AMBERHOME, 'lib')
+            CPPTRAJ_HEADERDIR = os.path.join(AMBERHOME, 'AmberTools', 'src',
+                                             'cpptraj', 'src')
 
         cpptraj_info.ambertools_distro = True
     else:

--- a/scripts/base_setup.py
+++ b/scripts/base_setup.py
@@ -363,8 +363,6 @@ def setenv_cc_cxx(ambertools_distro, extra_compile_args, extra_link_args):
         # should use CXX and CC from config.h
         amber_home = os.environ.get('AMBERHOME', '')
         if amber_home:
-            raise EnvironmentError('must set AMBERHOME')
-
             configfile = os.path.join(amber_home, 'config.h')
             if not os.path.exists(configfile):
                 raise OSError("must have config.h file")


### PR DESCRIPTION
It turns out I missed something when I manually merged my changes to base_setup.py.  I still need to add a block that will use the environment compilers if AMBERHOME is not defined.