### PR TITLE
CMake: disable openmp build on Macs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(pytraj)
 
 #figure out arguments
 
-if(OPENMP)
+if(OPENMP AND NOT TARGET_OSX) # pytraj will not build with OpenMP on macOS
 	set(OPENMP_ARG "")
 else()
 	set(OPENMP_ARG --disable-openmp)


### PR DESCRIPTION
With this change, you can build OpenMP Amber on Macs without getting errors from pytraj.  

This should fix the Jenkins CI build.