### PR TITLE
solve pca() degenerates input TrajectoryIterator issue

### DIFF
--- a/pytraj/trajectory/c_traj/c_trajectory.pyx
+++ b/pytraj/trajectory/c_traj/c_trajectory.pyx
@@ -555,7 +555,7 @@ cdef class TrajectoryCpptraj:
         return self
 
     def _remove_transformations(self):
-        self._actionlist = ActionList()
+        self._actionlist = ActionList(top=self.top)
         self._cdslist = CpptrajDatasetList()
         self._being_transformed = False
         self._being_superposed = False

--- a/pytraj/trajectory/c_traj/c_trajectory.pyx
+++ b/pytraj/trajectory/c_traj/c_trajectory.pyx
@@ -556,8 +556,6 @@ cdef class TrajectoryCpptraj:
 
     def _remove_transformations(self):
         self._initialize_actionlist()
-        #self._actionlist = ActionList(top=self.top)
-        #self._cdslist = CpptrajDatasetList()
         self._being_transformed = False
         self._being_superposed = False
         self._transform_commands = []

--- a/pytraj/trajectory/c_traj/c_trajectory.pyx
+++ b/pytraj/trajectory/c_traj/c_trajectory.pyx
@@ -555,8 +555,9 @@ cdef class TrajectoryCpptraj:
         return self
 
     def _remove_transformations(self):
-        self._actionlist = ActionList(top=self.top)
-        self._cdslist = CpptrajDatasetList()
+        self._initialize_actionlist()
+        #self._actionlist = ActionList(top=self.top)
+        #self._cdslist = CpptrajDatasetList()
         self._being_transformed = False
         self._being_superposed = False
         self._transform_commands = []

--- a/tests/test_analysis/test_pca.py
+++ b/tests/test_analysis/test_pca.py
@@ -227,6 +227,8 @@ class TestPCA(unittest.TestCase):
             traj_on_disk, mask='@CA', n_vecs=2, fit=fit, ref=ref0)
         data1, _ = pt.pca(traj_on_mem, mask='@CA', n_vecs=2, fit=fit, ref=ref1)
         aa_eq(np.abs(data0), np.abs(data1))
+        data2, _ = pt.pca(
+            traj_on_disk, mask='@CA', n_vecs=2, fit=fit, ref=ref0)
 
     def test_traj_on_disk_fit_to_given_reference_and_restore_transform_commands(
             self):

--- a/tests/test_analysis/test_pca.py
+++ b/tests/test_analysis/test_pca.py
@@ -231,6 +231,7 @@ class TestPCA(unittest.TestCase):
         # https://github.com/Amber-MD/pytraj/issues/1452
         data2, _ = pt.pca(
             traj_on_disk, mask='@CA', n_vecs=2, fit=fit, ref=ref0)
+        aa_eq(np.abs(data0), np.abs(data2))
 
     def test_traj_on_disk_fit_to_given_reference_and_restore_transform_commands(
             self):

--- a/tests/test_analysis/test_pca.py
+++ b/tests/test_analysis/test_pca.py
@@ -227,6 +227,8 @@ class TestPCA(unittest.TestCase):
             traj_on_disk, mask='@CA', n_vecs=2, fit=fit, ref=ref0)
         data1, _ = pt.pca(traj_on_mem, mask='@CA', n_vecs=2, fit=fit, ref=ref1)
         aa_eq(np.abs(data0), np.abs(data1))
+        # try again
+        # https://github.com/Amber-MD/pytraj/issues/1452
         data2, _ = pt.pca(
             traj_on_disk, mask='@CA', n_vecs=2, fit=fit, ref=ref0)
 


### PR DESCRIPTION
The pca() function will degenerate the input TrajectoryIterator because of an inappropriate re-initiation of  actionlist. 
Also added a test to the test_pca.py to make sure the fix works.