### PR TITLE
WIP: The ReplaceAsterisk() function has been deprecated.

### DIFF
--- a/pytraj/core/c_core.pxd
+++ b/pytraj/core/c_core.pxd
@@ -163,7 +163,6 @@ cdef extern from "NameType.h":
         const char* opr_star "operator*" () const 
         char opr_idx "operator[]"(int) const 
         string Truncated() const 
-        void ReplaceAsterisk() 
 
 
 cdef class NameType:

--- a/pytraj/core/c_core.pyx
+++ b/pytraj/core/c_core.pyx
@@ -239,9 +239,6 @@ cdef class NameType:
         """return string"""
         return self.thisptr.Truncated().decode()
 
-    def replace_asterisk(self):
-        self.thisptr.ReplaceAsterisk()
-
     def __str__(self):
         return (self.thisptr.opr_star()).decode()
 


### PR DESCRIPTION
This should fix the breakage caused by https://github.com/Amber-MD/cpptraj/pull/777

Should be considered WORK IN PROGRESS until that PR is accepted.