### PR TITLE
WIP: Fixes to support building Python 3.8 wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ tests/TestListTravis.sh
 *nogit*
 Makefile
 set_env.sh
+venv
+__pycache__
 
 # editors
+.idea
 .vscode

--- a/devtools/builder/build_all.sh
+++ b/devtools/builder/build_all.sh
@@ -1,20 +1,30 @@
-#!/bin/sh
-
-# Must be in pytraj root folder
-
-# add cpptraj folder
-python -c "import auditwheel" || exit 1
+#!/usr/bin/env bash
+set -e
 
 function main(){
+    # Must be in pytraj root folder
+    cd "${pytraj_root}"
     # this function will be run in the end of this script
+    create_venv
+    export PATH="/tmp/pytraj_venv/bin:$PATH"
     devtools/mkrelease
     clone_or_update_cpptraj
     pip_linux
     pip_osx
     conda_linux
     conda_osx
+    rm -rf /tmp/pytraj_venv
 }
 
+
+function create_venv(){
+    if [ ! -d /tmp/pytraj_venv ]; then
+        # We need to place the venv outside the checkout so it does not get wiped out by 'git clean'
+        python3 -m venv /tmp/pytraj_venv
+        /tmp/pytraj_venv/bin/python -m pip install -U pip setuptools wheel
+        /tmp/pytraj_venv/bin/python -m pip install auditwheel numpy Cython
+    fi
+}
 
 function clone_or_update_cpptraj(){
     if [ ! -d cpptraj ]; then
@@ -26,7 +36,7 @@ function clone_or_update_cpptraj(){
 
 
 function pip_linux(){
-    sh devtools/builder/run_docker_build_wheels_linux.sh
+    devtools/builder/run_docker_build_wheels_linux.sh
 }
 
 
@@ -47,7 +57,7 @@ function conda_osx(){
     for pyver in 2.7 3.7 3.5 3.6; do
         conda build devtools/conda-recipe/pytraj --py $pyver
         tarfile=`conda build devtools/conda-recipe/pytraj --py $pyver --output`
-    
+
         build_dir=dist/conda/osx-64
         if [ ! -d $build_dir ]; then
             mkdir -p $build_dir
@@ -56,4 +66,5 @@ function conda_osx(){
     done
 }
 
+pytraj_root="$(realpath $(dirname $(readlink -f $0))/../..)"
 main "$@"

--- a/devtools/builder/run_docker_build_conda_linux.sh
+++ b/devtools/builder/run_docker_build_conda_linux.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+set -e
 
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/../../"; pwd;)
-# DOCKER_IMAGE=hainm/pytraj-build-box:2019-03 # centos-5; does not have python 3.7
-DOCKER_IMAGE=condaforge/linux-anvil # Miniconda only has python 3.7 on centos >= 6
+DOCKER_IMAGE=hainm/pytraj-build-box:2020-04.24  # centos-7
 
 docker info
 cat << EOF | docker run -i \
@@ -12,11 +12,12 @@ cat << EOF | docker run -i \
                         bash || exit $?
 
 set -x
+set -e
 cd /feedstock_root/
 
 export PATH=\$HOME/miniconda3/bin:\$PATH
 
-for pyver in 3.7 2.7 3.5 3.6; do
+for pyver in 2.7 3.5 3.6 3.7 3.8; do
     conda build devtools/conda-recipe/pytraj --py \$pyver
     tarfile=\`conda build devtools/conda-recipe/pytraj --py \$pyver --output\`
     echo "\$tarfile"

--- a/devtools/builder/run_docker_build_wheels_linux.sh
+++ b/devtools/builder/run_docker_build_wheels_linux.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+set -e
 
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/../../"; pwd;)
-DOCKER_IMAGE=hainm/pytraj-build-box:2019-03
+DOCKER_IMAGE=hainm/pytraj-build-box:2020-04-24
 
 docker info
 cat << EOF | docker run -i \
@@ -11,23 +12,24 @@ cat << EOF | docker run -i \
                         bash || exit $?
 
 set -x
+set -e
 cd /feedstock_root/
 
-export python=/opt/python/cp36-cp36m/bin/python
+export PATH="/opt/python/cp38-cp38/bin:\$PATH"
 
 if [ ! -d dist ]; then
-    \$python ./devtools/mkrelease
+    devtools/mkrelease
 fi
 
 if [ ! -d cpptraj ]; then
-    \$python scripts/install_libcpptraj.py github -openmp
+    python scripts/install_libcpptraj.py github -openmp
 else
     # (cd cpptraj && git pull && git clean -fdx .)
-    \$python scripts/install_libcpptraj.py -openmp
+    python scripts/install_libcpptraj.py -openmp
 fi
 
-cd dist
-\$python ../scripts/build_wheel.py pytraj*gz --manylinux-docker
+ls -la dist
+python scripts/build_wheel.py dist/pytraj*gz --manylinux-docker
 
-cd ..
+rm -rf scripts/__pycache__
 EOF

--- a/devtools/builder/upload.sh
+++ b/devtools/builder/upload.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+set -e
 
 function main(){
     upload_pip

--- a/devtools/ci/install_ambertools.sh
+++ b/devtools/ci/install_ambertools.sh
@@ -3,6 +3,5 @@ conda install ambertools=17 -c http://ambermd.org/downloads/ambertools/conda/ -y
 python_ver=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
 echo "python_ver" $python_ver
 
-rm -rf $HOME/miniconda3/envs/$myenv/lib/python$python_ver/site-packages/pytraj
-rm -rf $HOME/miniconda3/envs/$myenv/lib/python$python_ver/site-packages/pytraj-2.0.0-py3.6.egg-info
+rm -rf $HOME/miniconda3/envs/$myenv/lib/python$python_ver/site-packages/pytraj*
 rm $HOME/miniconda3/envs/$myenv/lib/libcpptraj*

--- a/devtools/ci/test_setup_command.py
+++ b/devtools/ci/test_setup_command.py
@@ -98,7 +98,7 @@ def test_install_libcpptraj_if_having_cpptraj_folder_here():
 
 def test_install_to_amberhome():
     fn = './fake_amberhome'
-    python_path = '{}/lib/python3.6/site-packages/'.format(fn)
+    python_path = '{}/lib/python3.8/site-packages/'.format(fn)
     mkdir_cmd = 'mkdir -p {}'.format(python_path)
     subprocess.check_call(mkdir_cmd, shell=True)
     full_name = os.path.abspath(fn)

--- a/devtools/mkrelease
+++ b/devtools/mkrelease
@@ -1,41 +1,16 @@
-#!/usr/bin/env python
+#!/usr/bin/env bash
+set -e
 
-import os
-import sys
-import subprocess
+pytraj_root="$(realpath $(dirname $(readlink -f $0))/..)"
+echo "Building in $pytraj_root using Python at $(which python)"
+cd "${pytraj_root}"
+git clean -fdx .
+sed -i 's/is_released = False/is_released = True/' scripts/base_setup.py
+python scripts/cythonize.py
 
-python = sys.prefix + '/bin/python'
+# build source package
+python setup.py sdist
+# restore to ISRELEASED = False
+git checkout scripts/base_setup.py
 
-cwd = os.getcwd()
-
-try:
-    sys.argv.remove('--amber')
-    ambertools_distro = True
-except ValueError:
-    ambertools_distro = False
-
-pytraj_dir = os.path.abspath(os.path.dirname(__file__) + '/../')
-print('pytraj_dir', pytraj_dir)
-os.chdir(pytraj_dir)
-
-subprocess.check_call('git clean -fdx .', shell=True)
-
-# change to release status
-with open('scripts/base_setup.py', 'r') as fh:
-    old_content = fh.read()
-    new_content = old_content.replace('is_released = False',
-                                      'is_released = True')
-
-with open('scripts/tmp.py', 'w') as fh:
-    fh.write(new_content)
-
-subprocess.check_call('mv scripts/tmp.py scripts/base_setup.py', shell=True)
-subprocess.check_call('{} scripts/cythonize.py'.format(python), shell=True)
-
-if not ambertools_distro:
-    # upload to pip
-    subprocess.check_call('{} setup.py sdist'.format(python), shell=True)
-    # restore to ISRELEASED = False
-    subprocess.check_call('git checkout scripts/base_setup.py', shell=True)
-
-os.chdir(cwd)
+cd -

--- a/scripts/cythonize.py
+++ b/scripts/cythonize.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import sys
 import Cython


### PR DESCRIPTION
Rewrites mkrelease to a shell script because it was only executing shell commands anyway.

Adds "set -e" to bash scripts to fail on error, and adds missing shebangs various places.

Creates a venv for the build script, instead of running "python setup.py sdist" with system python.