### PR TITLE
Fixed problem with bonded_indices() method of pytraj.Atom class

### DIFF
--- a/pytraj/core/topology_objects.pyx
+++ b/pytraj/core/topology_objects.pyx
@@ -54,7 +54,7 @@ cdef class Atom:
     def bonded_indices(self):
         """get bond indices that `self` bonds to
         """
-        cdef int[:] arr = np.empty(self.thisptr.Nbonds(), dtype='int')
+        cdef int[:] arr = np.empty(self.thisptr.Nbonds(), dtype='i4')
         cdef bond_iterator it
         cdef int i = 0
 

--- a/tests/test_topology_objects/test_topology_objects.py
+++ b/tests/test_topology_objects/test_topology_objects.py
@@ -14,6 +14,11 @@ class TestTopoloyObjects(unittest.TestCase):
         for idx, atom in enumerate(self.traj.top.atoms):
             assert atom.index == idx, 'residue index'
 
+    def test_atom_bonded_indices(self):
+        for atom in self.traj.top.atoms:
+            for idx in atom.bonded_indices():
+                assert atom.is_bonded_to(idx)
+
     def test_residue(self):
         for idx, res in enumerate(self.traj.top.residues):
             assert res.index == idx, 'residue index'


### PR DESCRIPTION
Fix #1531

I changed the dtype of arr from int to i4 and added a test.