### PR TITLE
WIP: remove runtime error in pytraj.topology.topology.Topology.to_parmed. 

### DIFF
--- a/pytraj/io.py
+++ b/pytraj/io.py
@@ -475,11 +475,8 @@ def write_traj(filename,
 
 
 def write_parm(filename=None, top=None, format='amberparm', overwrite=False):
-    if os.path.exists(filename) and not overwrite:
-        raise RuntimeError(
-            '{0} exists, must set overwrite=True'.format(filename))
     parm = ParmFile()
-    parm.write(filename=filename, top=top, format=format)
+    parm.write(filename=filename, top=top, format=format, overwrite=overwrite)
 
 
 def load_topology(filename, option=''):

--- a/pytraj/io.py
+++ b/pytraj/io.py
@@ -475,8 +475,11 @@ def write_traj(filename,
 
 
 def write_parm(filename=None, top=None, format='amberparm', overwrite=False):
+    if os.path.exists(filename) and not overwrite:
+        raise RuntimeError(
+            '{0} exists, must set overwrite=True'.format(filename))
     parm = ParmFile()
-    parm.write(filename=filename, top=top, format=format, overwrite=overwrite)
+    parm.write(filename=filename, top=top, format=format)
 
 
 def load_topology(filename, option=''):

--- a/pytraj/topology/topology.pyx
+++ b/pytraj/topology/topology.pyx
@@ -834,12 +834,11 @@ cdef class Topology:
         def __get__(self):
             return sum([atom.charge for atom in self.atoms])
 
-    def save(self, filename=None, format='AMBERPARM', overwrite=False):
+    def save(self, filename=None, format='AMBERPARM'):
         """save to given file format (parm7, psf, ...)
         """
         parm = ParmFile()
-        parm.write(filename=filename, top=self, format=format,
-                       overwrite=overwrite)
+        parm.write(filename=filename, top=self, format=format)
 
     def set_solvent(self, mask):
         '''set ``mask`` as solvent
@@ -873,7 +872,7 @@ cdef class Topology:
         from pytraj.utils import tempfolder
 
         with tempfolder():
-            self.save("tmp.prmtop", overwrite=True)
+            self.save("tmp.prmtop")
             return pmd.load_file("tmp.prmtop")
 
 cdef class ParmFile:
@@ -909,7 +908,7 @@ cdef class ParmFile:
                 _top.thisptr[0], filename, arglist.thisptr[0], debug)
 
     def write(self, Topology top=Topology(), filename="default.top",
-                  ArgList arglist=ArgList(), format="", overwrite=False):
+                  ArgList arglist=ArgList(), format=""):
         cdef int debug = 0
         cdef int err
         # change `for` to upper
@@ -927,10 +926,6 @@ cdef class ParmFile:
 
         if top.is_empty():
             raise ValueError("empty topology")
-
-        if os.path.exists(filename) and not overwrite:
-            raise RuntimeError(
-                '{0} exists, must set overwrite=True'.format(filename))
 
         err = self.thisptr.WriteTopology(
             top.thisptr[0], filename, arglist.thisptr[0], parmtype, debug)

--- a/pytraj/topology/topology.pyx
+++ b/pytraj/topology/topology.pyx
@@ -834,11 +834,12 @@ cdef class Topology:
         def __get__(self):
             return sum([atom.charge for atom in self.atoms])
 
-    def save(self, filename=None, format='AMBERPARM'):
+    def save(self, filename=None, format='AMBERPARM', overwrite=False):
         """save to given file format (parm7, psf, ...)
         """
         parm = ParmFile()
-        parm.write(filename=filename, top=self, format=format)
+        parm.write(filename=filename, top=self, format=format,
+                       overwrite=overwrite)
 
     def set_solvent(self, mask):
         '''set ``mask`` as solvent
@@ -908,7 +909,7 @@ cdef class ParmFile:
                 _top.thisptr[0], filename, arglist.thisptr[0], debug)
 
     def write(self, Topology top=Topology(), filename="default.top",
-                  ArgList arglist=ArgList(), format=""):
+                  ArgList arglist=ArgList(), format="", overwrite=False):
         cdef int debug = 0
         cdef int err
         # change `for` to upper
@@ -926,6 +927,10 @@ cdef class ParmFile:
 
         if top.is_empty():
             raise ValueError("empty topology")
+
+        if os.path.exists(filename) and not overwrite:
+            raise RuntimeError(
+                '{0} exists, must set overwrite=True'.format(filename))
 
         err = self.thisptr.WriteTopology(
             top.thisptr[0], filename, arglist.thisptr[0], parmtype, debug)


### PR DESCRIPTION
When the to_parmed method of the pytraj.topology.topology.Topology class is invoked, the
I got the following error.
```
  File "pytraj/topology/topology.pyx", line 874, in pytraj.topology.topology.Topology.to_parmed
  File "pytraj/topology/topology.pyx", line 875, in pytraj.topology.topology.Topology.to_parmed
  File "pytraj/topology/topology.pyx", line 837, in pytraj.topology.topology.Topology.save
TypeError: save() got an unexpected keyword argument 'overwrite'
```
python: 3.8.1
cpptraj: V4.26.2 (GitHub)
pytraj: 2.0.5.dev0
ParmEd: 3.2.0

The reason for this error is that Topology.save does not have an argument 'overwrite'.
So, I added 'overwrite' to the argument of ParmFile.write as well as Topology.save.

Of course, we can also remove overwrite=True from Topology.to_parmed (line 875 of topology.pyx).
Which solution would be more preferable?
