### PR TITLE
ADD a test for pytraj.topology.topology.Topology.to_parmed

### DIFF
--- a/tests/test_external_loading/test_parmed_converter.py
+++ b/tests/test_external_loading/test_parmed_converter.py
@@ -15,18 +15,23 @@ except ImportError:
 
 @unittest.skipIf(pmd is None, "Must install ParmEd")
 class TestParmEdConverter(unittest.TestCase):
-    def test_parmed_converter(self):
-        traj = pt.iterload(fn('tz2.nc'), fn('tz2.parm7'))
-        parm = pmd.load_file(traj.top.filename)
-        parm2 = to_parmed(traj)
+    def setUp(self):
+        self.traj = pt.iterload(fn('tz2.nc'), fn('tz2.parm7'))
+        self.parm = pmd.load_file(self.traj.top.filename)
 
+    def parm_eq(self, parm, parm2):
         for atom, atom2 in zip(parm.atoms, parm2.atoms):
             assert atom.name == atom2.name, 'equal name'
             assert atom.type == atom2.type, 'equal type'
             assert atom.mass == atom2.mass, 'equal mass'
-            assert atom.atomic_number == atom2.atomic_number, 'equal atomic_number'
+            assert atom.atomic_number == atom2.atomic_number, \
+                'equal atomic_number'
             assert atom.residue.name == atom2.residue.name, 'residue name'
             aa_eq(atom.charge, atom2.charge, decimal=4)
+
+    def test_parmed_converter(self):
+        self.parm_eq(self.parm, to_parmed(self.traj))
+        self.parm_eq(self.parm, self.traj.top.to_parmed())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a test for pytraj.topology.topology.to_parmed in relation to #1533.

In an environment where ParmEd 3.2.0 is installed, the newly added test succeeded.
```
test_external_loading/test_parmed_converter.py::TestParmEdConverter::test_parmed_converter PASSED
```