### PR TITLE
remove warnings about numpy

### DIFF
--- a/pytraj/parallel/dataset.py
+++ b/pytraj/parallel/dataset.py
@@ -36,32 +36,32 @@ class PmapDataset(object):
         # val : Tuple[OrdereDict, n_frames]
 
         if self.func in [matrix.dist, matrix.idea, volmap]:
-            mat = np.sum((val[0] * val[1]
-                          for val in self.data)) / self.traj.n_frames
+            mat = sum([val[0] * val[1]
+                       for val in self.data]) / self.traj.n_frames
             return mat
         elif self.func in [
                 ired_vector_and_matrix,
         ]:
             # val : Tuple[(vecs, mat), n_frames]
-            mat = np.sum((val[0][1] * val[1]
-                          for val in self.data)) / self.traj.n_frames
-            vecs = np.column_stack(val[0][0] for val in self.data)
+            mat = sum([val[0][1] * val[1]
+                       for val in self.data]) / self.traj.n_frames
+            vecs = np.column_stack([val[0][0] for val in self.data])
             return (vecs, mat)
         elif self.func in [
                 rotation_matrix,
         ]:
             if 'with_rmsd' in self.kwargs.keys() and self.kwargs['with_rmsd']:
                 # val : Tuple[(mat, rmsd), n_frames]
-                mat = np.row_stack(val[0][0] for val in self.data)
-                rmsd_ = np.hstack(val[0][1] for val in self.data)
+                mat = np.row_stack([val[0][0] for val in self.data])
+                rmsd_ = np.hstack([val[0][1] for val in self.data])
                 return OrderedDict(out=(mat, rmsd_))
             else:
                 # val : Tuple[mat, n_frames]
-                mat = np.row_stack(val[0] for val in self.data)
+                mat = np.row_stack([val[0] for val in self.data])
                 return OrderedDict(mat=mat)
         elif self.func == mean_structure:
-            xyz = np.sum((x[1] * x[0].xyz
-                          for x in self.data)) / self.traj.n_frames
+            xyz = sum([x[1] * x[0].xyz
+                       for x in self.data]) / self.traj.n_frames
             frame = Frame(xyz.shape[0])
             frame.xyz[:] = xyz
             return frame

--- a/pytraj/parallel/dataset.py
+++ b/pytraj/parallel/dataset.py
@@ -36,28 +36,28 @@ class PmapDataset(object):
         # val : Tuple[OrdereDict, n_frames]
 
         if self.func in [matrix.dist, matrix.idea, volmap]:
-            mat = np.sum((val[0] * val[1]
-                          for val in self.data)) / self.traj.n_frames
+            mat = sum([val[0] * val[1]
+                       for val in self.data]) / self.traj.n_frames
             return mat
         elif self.func in [
                 ired_vector_and_matrix,
         ]:
             # val : Tuple[(vecs, mat), n_frames]
-            mat = np.sum((val[0][1] * val[1]
-                          for val in self.data)) / self.traj.n_frames
-            vecs = np.column_stack(val[0][0] for val in self.data)
+            mat = sum([val[0][1] * val[1]
+                       for val in self.data]) / self.traj.n_frames
+            vecs = np.column_stack([val[0][0] for val in self.data])
             return (vecs, mat)
         elif self.func in [
                 rotation_matrix,
         ]:
             if 'with_rmsd' in self.kwargs.keys() and self.kwargs['with_rmsd']:
                 # val : Tuple[(mat, rmsd), n_frames]
-                mat = np.row_stack(val[0][0] for val in self.data)
-                rmsd_ = np.hstack(val[0][1] for val in self.data)
+                mat = np.row_stack([val[0][0] for val in self.data])
+                rmsd_ = np.hstack([val[0][1] for val in self.data])
                 return OrderedDict(out=(mat, rmsd_))
             else:
                 # val : Tuple[mat, n_frames]
-                mat = np.row_stack(val[0] for val in self.data)
+                mat = np.row_stack([val[0] for val in self.data])
                 return OrderedDict(mat=mat)
         elif self.func == mean_structure:
             xyz = np.sum((x[1] * x[0].xyz

--- a/pytraj/parallel/dataset.py
+++ b/pytraj/parallel/dataset.py
@@ -36,32 +36,32 @@ class PmapDataset(object):
         # val : Tuple[OrdereDict, n_frames]
 
         if self.func in [matrix.dist, matrix.idea, volmap]:
-            mat = sum([val[0] * val[1]
-                       for val in self.data]) / self.traj.n_frames
+            mat = np.sum((val[0] * val[1]
+                          for val in self.data)) / self.traj.n_frames
             return mat
         elif self.func in [
                 ired_vector_and_matrix,
         ]:
             # val : Tuple[(vecs, mat), n_frames]
-            mat = sum([val[0][1] * val[1]
-                       for val in self.data]) / self.traj.n_frames
-            vecs = np.column_stack([val[0][0] for val in self.data])
+            mat = np.sum((val[0][1] * val[1]
+                          for val in self.data)) / self.traj.n_frames
+            vecs = np.column_stack(val[0][0] for val in self.data)
             return (vecs, mat)
         elif self.func in [
                 rotation_matrix,
         ]:
             if 'with_rmsd' in self.kwargs.keys() and self.kwargs['with_rmsd']:
                 # val : Tuple[(mat, rmsd), n_frames]
-                mat = np.row_stack([val[0][0] for val in self.data])
-                rmsd_ = np.hstack([val[0][1] for val in self.data])
+                mat = np.row_stack(val[0][0] for val in self.data)
+                rmsd_ = np.hstack(val[0][1] for val in self.data)
                 return OrderedDict(out=(mat, rmsd_))
             else:
                 # val : Tuple[mat, n_frames]
-                mat = np.row_stack([val[0] for val in self.data])
+                mat = np.row_stack(val[0] for val in self.data)
                 return OrderedDict(mat=mat)
         elif self.func == mean_structure:
-            xyz = sum([x[1] * x[0].xyz
-                       for x in self.data]) / self.traj.n_frames
+            xyz = np.sum((x[1] * x[0].xyz
+                          for x in self.data)) / self.traj.n_frames
             frame = Frame(xyz.shape[0])
             frame.xyz[:] = xyz
             return frame

--- a/pytraj/parallel/dataset.py
+++ b/pytraj/parallel/dataset.py
@@ -60,8 +60,8 @@ class PmapDataset(object):
                 mat = np.row_stack([val[0] for val in self.data])
                 return OrderedDict(mat=mat)
         elif self.func == mean_structure:
-            xyz = np.sum((x[1] * x[0].xyz
-                          for x in self.data)) / self.traj.n_frames
+            xyz = sum([x[1] * x[0].xyz
+                       for x in self.data]) / self.traj.n_frames
             frame = Frame(xyz.shape[0])
             frame.xyz[:] = xyz
             return frame

--- a/pytraj/utils/get_common_objects.py
+++ b/pytraj/utils/get_common_objects.py
@@ -264,17 +264,18 @@ class super_dispatch(object):
             frame_indices = kwargs.get('frame_indices')
             top = kwargs.get('top')
 
-            if has_mask_arg and mask == '':
-                if has_traj_arg:
-                    try:
-                        mask = args[0]
-                    except IndexError:
-                        mask = ''
-                else:
-                    try:
-                        mask = args[1]
-                    except IndexError:
-                        mask = ''
+            if has_mask_arg and isinstance(mask, string_types):
+                if mask == '':
+                    if has_traj_arg:
+                        try:
+                            mask = args[0]
+                        except IndexError:
+                            mask = ''
+                    else:
+                        try:
+                            mask = args[1]
+                        except IndexError:
+                            mask = ''
 
             if has_ref_arg:
                 if ref is None:

--- a/pytraj/utils/tools.py
+++ b/pytraj/utils/tools.py
@@ -309,7 +309,7 @@ def merge_coordinates(iterables):
            [ 34.4160347 ,   8.53098011,  15.01716137],
            [ 34.29132462,   8.27471733,  16.50368881]])
     """
-    return np.vstack((f.xyz.copy() for f in iterables))
+    return np.vstack([f.xyz.copy() for f in iterables])
 
 
 def merge_frames(iterables):
@@ -324,7 +324,7 @@ def merge_frames(iterables):
     <Frame with 15879 atoms>
     """
     from pytraj import Frame
-    xyz = np.vstack((f.xyz.copy() for f in iterables))
+    xyz = np.vstack([f.xyz.copy() for f in iterables])
     frame = Frame()
     frame.append_xyz(xyz)
     return frame

--- a/pytraj/utils/tools.py
+++ b/pytraj/utils/tools.py
@@ -309,7 +309,7 @@ def merge_coordinates(iterables):
            [ 34.4160347 ,   8.53098011,  15.01716137],
            [ 34.29132462,   8.27471733,  16.50368881]])
     """
-    return np.vstack([f.xyz.copy() for f in iterables])
+    return np.vstack((f.xyz.copy() for f in iterables))
 
 
 def merge_frames(iterables):
@@ -324,7 +324,7 @@ def merge_frames(iterables):
     <Frame with 15879 atoms>
     """
     from pytraj import Frame
-    xyz = np.vstack([f.xyz.copy() for f in iterables])
+    xyz = np.vstack((f.xyz.copy() for f in iterables))
     frame = Frame()
     frame.append_xyz(xyz)
     return frame


### PR DESCRIPTION
When running the test, warnings about numpy occur, such as the following.
So, I have modified it so that there is no warning for the future.

```
  pytraj/pytraj/parallel/dataset.py:39: DeprecationWarning: Calling np.sum(generator) is deprecated, and in the future will give a different result. Use np.sum(np.fromiter(generator)) or the python sum builtin instead.
    mat = np.sum((val[0] * val[1]
  pytraj/pytraj/parallel/dataset.py:46: DeprecationWarning: Calling np.sum(generator) is deprecated, and in the future will give a different result. Use np.sum(np.fromiter(generator)) or the python sum builtin instead.
    mat = np.sum((val[0][1] * val[1]
  pytraj/pytraj/parallel/dataset.py:48: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
    vecs = np.column_stack(val[0][0] for val in self.data)
  pytraj/pytraj/parallel/dataset.py:55: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
    mat = np.row_stack(val[0][0] for val in self.data)
  pytraj/pytraj/parallel/dataset.py:56: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
    rmsd_ = np.hstack(val[0][1] for val in self.data)
  pytraj/pytraj/parallel/dataset.py:60: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
    mat = np.row_stack(val[0] for val in self.data)
  pytraj/pytraj/parallel/dataset.py:63: DeprecationWarning: Calling np.sum(generator) is deprecated, and in the future will give a different result. Use np.sum(np.fromiter(generator)) or the python sum builtin instead.
    xyz = np.sum((x[1] * x[0].xyz

  pytraj/pytraj/utils/get_common_objects.py:267: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
    if has_mask_arg and mask == '':

  pytraj/pytraj/utils/tools.py:312: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
    return np.vstack((f.xyz.copy() for f in iterables))
  pytraj/pytraj/utils/tools.py:327: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
    xyz = np.vstack((f.xyz.copy() for f in iterables))
