### PR TITLE
Fixed problem with angle_indices of pytraj.topology.topology.Topology

### DIFF
--- a/pytraj/core/parameter_types.pyx
+++ b/pytraj/core/parameter_types.pyx
@@ -24,8 +24,8 @@ cdef class AngleType:
     @property
     def indices(self):
         """return atom indices as a python array"""
-        np.array([self.thisptr.A1(),
-                                         self.thisptr.A2(), self.thisptr.A3()])
+        return np.array([self.thisptr.A1(),
+                         self.thisptr.A2(), self.thisptr.A3()])
 
 
 cdef class LES_AtomType:

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -116,6 +116,11 @@ class TestTopology(unittest.TestCase):
         assert len(top[:]) == top.n_atoms
         assert len(top[:10]) == 10
 
+        # API
+        top.bond_indices
+        top.angle_indices
+        top.dihedral_indices
+
     def test_simplifed_topology(self):
         '''simplify'''
         top = pt.load_topology(fn('Tc5b.top'))


### PR DESCRIPTION
When I called angle_indices of the pytraj.topology.topology.Topology,
I got the following error.

```
  File "pytraj/topology/topology.pyx", line 751, in pytraj.topology.topology.Topology.angle_indices.__get__
  File "/home/uchida/cnt/enhancer/utils/.venv/lib/python3.7/site-packages/numpy/core/_asarray.py", line 85, in asarray
    return array(a, dtype, copy=False, order=order)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```
I added a `return` statement at the end of `indeces` in pytraj.core.parameter_types.AtomType and also added a test.
