### PR TITLE
FIX memory leak in stripping

### DIFF
--- a/pytraj/topology/topology.pyx
+++ b/pytraj/topology/topology.pyx
@@ -577,7 +577,7 @@ cdef class Topology:
             atm = self(mask)
             return self._modify_state_by_mask(atm)
 
-    def strip(Topology self, mask, copy=False):
+    def strip(Topology self, mask):
         """strip atoms with given mask"""
         cdef AtomMask atm
         cdef Topology new_top
@@ -587,12 +587,11 @@ cdef class Topology:
         if atm.n_atoms == 0:
             raise ValueError("number of stripped atoms must be > 1")
         atm.invert_mask()
-        new_top = self._modify_state_by_mask(atm)
 
-        if copy:
-            return new_top
-        else:
-            self.thisptr[0] = new_top.thisptr[0]
+        cdef _Topology *top_ptr = self.thisptr.modifyStateByMask(atm.thisptr[0])
+        # Delete existing topology to avoid memory leak
+        del self.thisptr
+        self.thisptr = top_ptr
 
     def is_empty(self):
         return self.n_atoms == 0

--- a/pytraj/trajectory/stripped_trajectory.py
+++ b/pytraj/trajectory/stripped_trajectory.py
@@ -18,7 +18,8 @@ class StrippedTrajectoryIterator(SharedTrajectory):
     """
 
     def __init__(self, origtraj, mask):
-        top = origtraj.top.strip(mask, copy=True)
+        top = origtraj.top.copy()
+        top.strip(mask)
         self.top = top
         self._traj = origtraj
         self._atm = self._traj.top(mask)

--- a/scripts/memory/topology_test.py
+++ b/scripts/memory/topology_test.py
@@ -1,0 +1,14 @@
+import pytraj as pt
+from memory_profiler import profile
+
+orig_top = pt.load_topology('../../tests/data/tz2.parm7')
+
+
+def test():
+    for i in range(100000000):
+        print(i)
+        top = orig_top.copy()
+        top.strip(":1")
+
+
+test()


### PR DESCRIPTION
https://github.com/Amber-MD/pytraj/issues/1495

Below code should run without increasing memory
```python
import pytraj as pt

orig_top = pt.load_topology('../../tests/data/tz2.parm7')


def test():
    for i in range(100000000):
        print(i)
        top = orig_top.copy()
        top.strip(":1")


test()
```