### PR TITLE
Fix disappearing forces when slicing

### DIFF
--- a/pytraj/trajectory/c_traj/c_trajectory.pyx
+++ b/pytraj/trajectory/c_traj/c_trajectory.pyx
@@ -467,6 +467,7 @@ cdef class TrajectoryCpptraj:
 
         else:
             traj.velocities = np.zeros((n_frames, n_atoms, 3), dtype='f8')
+            traj.forces = np.zeros((n_frames, n_atoms, 3), dtype='f8')
             # slower
             frame = Frame()
             frame.thisptr[0] = self.thisptr.AllocateFrame()
@@ -481,6 +482,7 @@ cdef class TrajectoryCpptraj:
                 traj.xyz[j] = frame.xyz
                 traj.unitcells[j] = frame.box._get_data()
                 traj.velocities[j] = frame.velocity
+                traj.forces[j] = frame.force
                 if has_time:
                     traj.time[j] = frame.time
             return traj


### PR DESCRIPTION
When iterating over a sliced trajectory which contains forces, the forces were not included in the new sliced trajectory, this fixes that.

Before:

```
>>> import pytraj as pt
>>> traj = pt.iterload('03_Prod.nc','parm7')
>>> traj[0:5][0].force
>>>
```

After:

```
>>> import pytraj as pt
>>> traj = pt.iterload('03_Prod.nc','parm7')
>>> traj[0:5][0].force
array([[ -3.07928634,   0.68935108,  -0.12736608],
       [  7.64932537, -19.16348267, -16.6106205 ],
       [ -2.71725702,  -1.42881477,   8.08388519],
       ...,
       [  9.62166405,  -1.84283781,  -4.25340939],
       [  0.85549378,   5.10778189, -12.62469864],
       [ -8.67284012,   3.77264452,   8.0937624 ]])
```