### PR TITLE
Fix Jcoupling test

### DIFF
--- a/tests/test_analysis/test_jcoupling.py
+++ b/tests/test_analysis/test_jcoupling.py
@@ -7,7 +7,7 @@ from pytraj.testing import aa_eq, cpptraj_test_dir
 
 def test_jcoupling():
     kfile = os.path.abspath(
-        os.path.join(cpptraj_test_dir, "Test_Jcoupling", "Karplus.txt"))
+        os.path.join(cpptraj_test_dir, "../dat/Karplus.txt"))
     traj = pt.iterload(fn('tz2.nc'), fn('tz2.parm7'))
 
     d1 = pt.jcoupling(traj, kfile=kfile)


### PR DESCRIPTION
This is a workaround, pointing the Jcoupling test to the new location of the Karplus.txt file in cpptraj. @hainm I initially tried to create a new variable called cpptraj_dat_dir in testing.py (code below), but I kept getting an ImportError. This should work for now.

```python
__all__ = [
    'load_sample_data', 'eq', 'aa_eq', 'duplicate_traj', 'Timer', 'tempfolder',
    'amberhome', 'cpptraj_test_dir', 'cpptraj_dat_dir', 'get_fn', 'get_remd_fn',
    'assert_equal_topology'
]
```

`<snip>`

```python
if cpptrajhome:
    cpptraj_test_dir = os.path.join(cpptrajhome, 'test')
    cpptraj_dat_dir = os.path.join(cpptrajhome, 'dat')
else:
    if amberhome:
        cpptraj_test_dir = os.path.join(amberhome, 'AmberTools', 'src',
                                        'cpptraj', 'test')
        cpptraj_dat_dir = os.path.join(amberhome, 'dat')
    else:
        cpptrajhome = ''
        amberhome = ''
        cpptraj_test_dir = ''
        cpptraj_dat_dir = ''

DEFAULT_PATH = os.path.dirname(__file__) + "/../../cpptraj"

if os.path.exists(DEFAULT_PATH):
    cpptraj_test_dir = os.path.abspath(os.path.join(DEFAULT_PATH, 'test'))
    cpptraj_dat_dir = os.path.abspath(os.path.join(DEFAULT_PATH, 'dat'))
```

`<snip>`

```python
if __name__ == "__main__":
    print(amberhome)
    print(cpptraj_test_dir)
    print(cpptraj_dat_dir)
```