### PR TITLE
test python 3.8 with latest cpptraj

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,7 @@ language: cpp
 
 matrix:
   include:
-    - { os: linux, env: PYTHON_VERSION=3.6 }
-    - { os: linux, env: PYTHON_VERSION=3.7 }
-    - { os: linux, env: PYTHON_VERSION=3.8 }
-    - { os: linux, env: PYTHON_VERSION=3.8 USE_OPENMP=false}
-    - { os: osx, env: PYTHON_VERSION=3.7 }
+    - { os: osx, env: PYTHON_VERSION=3.8 }
 
 
 sudo: false


### PR DESCRIPTION
It seems to me that https://github.com/Amber-MD/cpptraj/pull/853 causes segmentation fault in `pytraj`

```
import pytraj as pt                                                                                                                         

pt._verbose()
traj = pt.iterload('./run_nowater.nc', './wbox_no_water_ions.prmtop')  
```
```
	Reading './wbox_no_water_ions.prmtop' as Amber Topology
	Radius Set: modified Bondi radii (mbondi)
```
