### PR TITLE
Add ability to set RNG in tests

### DIFF
--- a/pytraj/__init__.py
+++ b/pytraj/__init__.py
@@ -225,6 +225,8 @@ from .core.c_options import set_world_silent
 from .core.c_options import set_cpptraj_verbose
 from .core.c_options import set_cpptraj_verbose as _verbose
 set_world_silent(True)
+# Allow tests to set RNG back to Marsaglia
+from .core.c_options import set_default_rng
 
 # alias
 write_trajectory = write_traj

--- a/pytraj/core/c_options.pyx
+++ b/pytraj/core/c_options.pyx
@@ -21,6 +21,18 @@ def info():
     s = Cpptraj.Defines()
     return s.decode()
 
+# These are functions in cpptraj specially wrapped for pytraj
+cdef extern from "ExternalFxn.h":
+    void EXT_SetDefaultRng(int)
+
+## set_default_rng
+#
+# This calls Cpptraj::Random_Number::SetDefaultRng() to change default
+# random number generator. Primarily used for tests to set the RNG
+# back to the old Marsaglia generator (rtype 0).
+def set_default_rng(rtype):
+    EXT_SetDefaultRng(rtype) 
+
 cdef extern from "CpptrajStdio.h":
     void SuppressErrorMsg(bint)
     void SetWorldSilent(bint)

--- a/tests/test_analysis/test_randomize_ions.py
+++ b/tests/test_analysis/test_randomize_ions.py
@@ -17,7 +17,8 @@ class TestRandomizeIons(unittest.TestCase):
                           'adh206.ff10.tip3p.parm7.gz')
         saved_traj_name = os.path.join(cpptraj_test_dir, 'Test_RandomizeIons',
                                        'random.crd.save')
-
+        # Set default RNG back to Marsaglia
+        pt.set_default_rng(0)
         traj = pt.iterload(fn, tn)
         traj_mut = traj[:]
         saved_traj = pt.iterload(saved_traj_name, traj.top)

--- a/tests/test_analysis/test_velocity.py
+++ b/tests/test_analysis/test_velocity.py
@@ -16,7 +16,8 @@ class TestVelocity(unittest.TestCase):
         saved_rst7 = pt.iterload(
             os.path.join(cpptraj_test_dir, 'Test_SetVelocity',
                          'tz2.vel.rst7.save'), fn('tz2.parm7'))
-
+        # Set default RNG back to Marsaglia
+        pt.set_default_rng(0)
         pt.set_velocity(traj, temperature=298, ig=10)
         aa_eq(traj[0].velocity, saved_rst7[0].velocity)
 


### PR DESCRIPTION
Related to cpptraj [PR 882](https://github.com/Amber-MD/cpptraj/pull/882), adds ability for pytraj to set what RNG will be used. This will make it so tests can pass if the default RNG is changed. 

@hainm sorry this is pretty rough code, you may want to make it a nicer interface eventually (like taking strings or enum instead of `int` ).