### PR TITLE
Use positive index instead of negative to select data set in cluster test case

### DIFF
--- a/tests/test_analysis/test_cluster.py
+++ b/tests/test_analysis/test_cluster.py
@@ -63,7 +63,7 @@ def test_cluster_dbscan():
         traj = pt.iterload(tz2_trajin, tz2_top)
         data = pt.cluster.dbscan(
             traj, mask='@CA', options='epsilon 1.7 minpoints 5')
-        aa_eq(state.data[-2], data.cluster_index)
+        aa_eq(state.data[2], data.cluster_index)
 
 
 def test_cluster_hieragglo():
@@ -81,4 +81,4 @@ def test_cluster_hieragglo():
         traj = pt.iterload(tz2_trajin, tz2_top)
         data = pt.cluster.hieragglo(
             traj, mask='!@H=', options='epsilon 0.8 averagelinkage')
-        aa_eq(state.data[-2], data.cluster_index)
+        aa_eq(state.data[2], data.cluster_index)


### PR DESCRIPTION
Hopefully this will future-proof the test case in case cluster ends up generating more sets. 

@hainm It would be better long-term to be able to select by DataSet name/aspect.