### PR TITLE
Fix memory leak on topology mask selection

### DIFF
--- a/pytraj/topology/topology.pyx
+++ b/pytraj/topology/topology.pyx
@@ -542,12 +542,16 @@ cdef class Topology:
 
     def _partial_modify_state_by_mask(self, AtomMask m):
         cdef Topology top = Topology()
-        top.thisptr[0] = deref(self.thisptr.partialModifyStateByMask(m.thisptr[0]))
+        newtop_ptr = self.thisptr.partialModifyStateByMask(m.thisptr[0])
+        top.thisptr[0] = deref(newtop_ptr)
+        del newtop_ptr
         return top
 
     def _modify_state_by_mask(self, AtomMask m):
         cdef Topology top = Topology()
-        top.thisptr[0] = deref(self.thisptr.modifyStateByMask(m.thisptr[0]))
+        newtop_ptr = self.thisptr.modifyStateByMask(m.thisptr[0])
+        top.thisptr[0] = deref(newtop_ptr)
+        del newtop_ptr
         return top
 
     def _get_new_from_mask(self, mask=None):


### PR DESCRIPTION
Had a little look at the memory leak bug Amber-MD/pytraj#1615 as it was also annoying me.

Needed to delete the newParm pointer created by cpptraj after assignment as it remained on the heap. Not sure if this is the best way to handle it but it fixes the memory leak.