### PR TITLE
Import python build fix for AmberTools cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ install(CODE "
     \"CC=${CMAKE_C_COMPILER}\"
     ${RPATH_ARG}
     ${PYTHONPATH_SET_CMD}
-	${PYTHON_EXECUTABLE} ./setup.py build -b ${BUILD_DIR} ${OPENMP_ARG} ${PYTHON_COMPILER_ARG} ${WIN64_DEFINE_ARG} install ${PYTHON_PREFIX_ARG}
+	${PYTHON_EXECUTABLE} ./setup.py build -b ${BUILD_DIR} ${OPENMP_ARG} ${PYTHON_COMPILER_ARG} ${WIN64_DEFINE_ARG} install -f ${PYTHON_PREFIX_ARG} --single-version-externally-managed --root /
     WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\")")
 
 add_subdirectory(tests)


### PR DESCRIPTION
Pytraj was being built differently than other python programs in AmberTools, which was causing the build to fail on certain platforms. This PR adds the proper flags to be passed to `setup.py` in `CMakeLists.txt`.

Amber Gitlab reference: https://gitlab.ambermd.org/amber/amber/-/merge_requests/1238