### PR TITLE
Try to fix some test warnings that can be errors on certain platforms.

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -20,9 +20,9 @@ jobs:
         sudo apt-get install libfftw3-dev
         sudo apt-get install clang
         sudo apt-get install cmake-data cmake    
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8
     - name: Add conda to system path

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -31,10 +31,10 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        curl -OL ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.6.1.tar.gz
-        tar -zxf netcdf-4.6.1.tar.gz
-        cd netcdf-4.6.1
-        ./configure --disable-netcdf-4 --disable-dap --disable-doxygen --prefix=$HOME
+        curl -OL https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.9.2.tar.gz
+        tar -zxf v4.9.2.tar.gz 
+        cd netcdf-c-4.9.2
+        ./configure --disable-byterange --disable-libxml2 --disable-netcdf-4 --disable-dap --disable-doxygen --prefix=$HOME
         make -j2
         make install
         cd ..

--- a/pytraj/utils/tools.py
+++ b/pytraj/utils/tools.py
@@ -628,7 +628,7 @@ def read_to_array(fname):
     '''read text from file to numpy array'''
     import numpy as np
     with open(fname, 'r') as fh:
-        arr0 = np.array([[x for x in line.split()] for line in fh.readlines()])
+        arr0 = np.array([[x for x in line.split()] for line in fh.readlines()], dtype=object)
         return np.array(flatten(arr0), dtype='f8')
 
 

--- a/tests/test_analysis/test_rmsd.py
+++ b/tests/test_analysis/test_rmsd.py
@@ -172,8 +172,10 @@ class TestSimpleRMSD(unittest.TestCase):
 
         ca = pt.select('@CA', traj.top)
         cb = pt.select('@CB', traj.top)
-        aa_eq(pt.rmsd(traj, mask=ca), pt.rmsd(traj, mask=[ca, cb])[0])
-        aa_eq(pt.rmsd(traj, mask=cb), pt.rmsd(traj, mask=[ca, cb])[1])
+        mask_3 = np.array([ca, cb], dtype=object)
+        rmsd_3 = pt.rmsd(traj, mask=mask_3)
+        aa_eq(pt.rmsd(traj, mask=ca), rmsd_3[0])
+        aa_eq(pt.rmsd(traj, mask=cb), rmsd_3[1])
 
     def test_raise_savematrices_if_not_dataset(self):
         traj = self.traj.copy()

--- a/tests/test_analysis/test_rmsd.py
+++ b/tests/test_analysis/test_rmsd.py
@@ -162,11 +162,11 @@ class TestSimpleRMSD(unittest.TestCase):
             aa_eq(arr[idx], pt.rmsd(traj, mask=m))
             aa_eq(arr[idx], pt.rmsd(traj, mask=traj.top.select(m)))
 
-        mask = ['@CA', '@CB', ':3-18@CA,C', [0, 3, 5]]
+        mask = np.array(['@CA', '@CB', ':3-18@CA,C', [0, 3, 5]], dtype=object)
         with pytest.raises(TypeError):
             pt.rmsd(traj, mask=mask)
 
-        mask_2 = [[0, 3, 6], range(50)]
+        mask_2 = np.array([[0, 3, 6], range(50)], dtype=object)
         aa_eq(pt.rmsd(traj, mask=mask_2)[0], pt.rmsd(traj, mask=mask_2[0]))
         aa_eq(pt.rmsd(traj, mask=mask_2)[1], pt.rmsd(traj, mask=mask_2[1]))
 

--- a/tests/test_io/test_convert.py
+++ b/tests/test_io/test_convert.py
@@ -1,13 +1,14 @@
 from __future__ import print_function
 import unittest
 import pytraj as pt
+import numpy as np
 from utils import fn
 
 
 class Test(unittest.TestCase):
     def test_0(self):
-        mask = pt.utils.convert.array2d_to_cpptraj_maskgroup([[0, 3],
-                                                              [5, 6, 8]])
+        mask = pt.utils.convert.array2d_to_cpptraj_maskgroup(np.array([[0, 3],
+                                                              [5, 6, 8]], dtype=object))
         assert mask == '@1,4 @6,7,9'
 
 


### PR DESCRIPTION
Certain numpy deprecation warnings seem to be errors depending on the platform. In particular, this was causing a lot of spurious test failures on Jenkins. This PR attempts to fix the 3 most commonly failing tests on Jenkins:
```
=========================== short test summary info ============================

FAILED test_read_to_array.py::Test::test_0 - ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (11,) + inhomogeneous part.
FAILED test_analysis/test_rmsd.py::TestSimpleRMSD::test_list_of_masks - ValueError: don't mix different types
FAILED test_io/test_convert.py::Test::test_0 - ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part.
```
Mostly this is accomplished by some slight reorganization and by explicitly declaring numpy arrays with the `dtype=object` parameter. I do see other warnings, but the hope is that this will fix the failures on Jenkins.

This also fixes the github workflow, which was out of date and using an older and no-longer-supported NetCDF.