### PR TITLE
Fix python 3.11 test issues

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -22,7 +22,7 @@ jobs:
         sudo apt-get install cmake-data cmake    
     - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Add conda to system path

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 channels:
     - conda-forge
 dependencies:
+    - python=3.8
     - netcdf4
     - pyflakes
     - numpy

--- a/pytraj/parallel/dataset.py
+++ b/pytraj/parallel/dataset.py
@@ -45,7 +45,7 @@ class PmapDataset(object):
             # val : Tuple[(vecs, mat), n_frames]
             mat = np.sum((val[0][1] * val[1]
                           for val in self.data)) / self.traj.n_frames
-            vecs = np.column_stack(val[0][0] for val in self.data)
+            vecs = np.column_stack([val[0][0] for val in self.data])
             return (vecs, mat)
         elif self.func in [
                 rotation_matrix,

--- a/pytraj/trajectory/c_traj/c_trajectory.pyx
+++ b/pytraj/trajectory/c_traj/c_trajectory.pyx
@@ -318,9 +318,10 @@ cdef class TrajectoryCpptraj:
             return self.tmpfarray
         else:
             # not is a slice or string or AtomMask
-            if idxs == ():
-                return self
-            elif isinstance(idxs, tuple):
+            #if idxs == ():
+            #    return self
+            #el
+            if isinstance(idxs, tuple):
                 idxs_size = len(idxs)
                 if idxs_size >= 4:
                     raise NotImplementedError("number of elements must me smaller than 4")


### PR DESCRIPTION
Try to fix some test errors that seem to show up with python 3.11. @hainm please especially check the change in `c_trajectory.pyx1. I'm not completely certain of the intent behind the original code, but changing it to something like `if not idxs` did not fix the error.