### PR TITLE
rdf action should be able to return the raw-rdf values

### DIFF
--- a/pytraj/all_actions.py
+++ b/pytraj/all_actions.py
@@ -1132,7 +1132,7 @@ def rdf(traj=None,
         if True, calculate RDF from geometric center of atoms in solute_mask to all atoms in solvent_mask
     intramol : bool, default True, optional
         if False, ignore intra-molecular distances
-    frame_indices : array-like, default None, 
+    frame_indices : array-like, default None, optional
     raw_rdf : bool, default False, optional
         if True, return the raw (non-normalized) RDF values 
 

--- a/pytraj/all_actions.py
+++ b/pytraj/all_actions.py
@@ -1104,7 +1104,8 @@ def rdf(traj=None,
         center_solute=False,
         intramol=True,
         frame_indices=None,
-        top=None):
+        top=None,
+        raw_rdf=False):
     '''compute radial distribtion function. Doc was adapted lightly from cpptraj doc
 
     Returns
@@ -1131,7 +1132,9 @@ def rdf(traj=None,
         if True, calculate RDF from geometric center of atoms in solute_mask to all atoms in solvent_mask
     intramol : bool, default True, optional
         if False, ignore intra-molecular distances
-    frame_indices : array-like, default None, optional
+    frame_indices : array-like, default None, 
+    raw_rdf : bool, default False, optional
+        if True, return the raw (non-normalized) RDF values 
 
     Examples
     --------
@@ -1171,13 +1174,14 @@ def rdf(traj=None,
     center1_ = 'center1' if center_solvent else ''
     center2_ = 'center2' if center_solute else ''
     nointramol_ = 'nointramol' if not intramol else ''
+    raw_rdf_ = "rawrdf pytraj_tmp_output_raw.agr" if raw_rdf else ''
 
     # order does matters
     # the order between solventmask_ and solutemask_ is swapped compared
     # to cpptraj's doc (to get correct result)
     command = ' '.join(("pytraj_tmp_output.agr", spacing_, maximum_,
                         solventmask_, solutemask_, noimage_, density_, volume_,
-                        center1_, center2_, nointramol_))
+                        center1_, center2_, nointramol_, raw_rdf_))
 
     c_dslist, _ = do_action(traj, command, c_action.Action_Radial)
     # make a copy sine c_dslist[-1].values return view of its data

--- a/tests/test_analysis/test_rdf.py
+++ b/tests/test_analysis/test_rdf.py
@@ -25,6 +25,7 @@ class TestRDF(unittest.TestCase):
         radial radial.dat 0.5 10.0 :5@CD :WAT@O
         radial radial2.dat 0.25 10.0 :5@CD :WAT@O
         radial radial2.dat 0.25 10.0 :5@CD :WAT@O volume
+        radial RadialForRaw.agr 0.5 10.0 :5@CD :WAT@O rawrdf RadialRaw.agr
         '''
 
         state = pt.load_batch(traj, command)
@@ -46,6 +47,14 @@ class TestRDF(unittest.TestCase):
                 solute_mask=':WAT@O',
                 bin_spacing=0.5,
                 maximum=10.0)
+
+data01raw = pt.rdf(
+                traj,
+                solvent_mask=':5@CD',
+                solute_mask=':WAT@O',
+                bin_spacing=0.5,
+                maximum=10.0,
+                rawrdf=True)
 
             data1 = pt.rdf(
                 traj,
@@ -112,6 +121,7 @@ class TestRDF(unittest.TestCase):
             aa_eq(data3[1], state.data[4], decimal=7)
             aa_eq(data4[1], state.data[5], decimal=7)
             aa_eq(data7[1], state.data[8], decimal=7)
+            aa_eq(data01raw[1], state.data[9], decimal=7)
 
             # default solvent mask :WAT@O
             aa_eq(data01[1], state.data[1], decimal=7)

--- a/tests/test_analysis/test_rdf.py
+++ b/tests/test_analysis/test_rdf.py
@@ -48,14 +48,6 @@ class TestRDF(unittest.TestCase):
                 bin_spacing=0.5,
                 maximum=10.0)
 
-data01raw = pt.rdf(
-                traj,
-                solvent_mask=':5@CD',
-                solute_mask=':WAT@O',
-                bin_spacing=0.5,
-                maximum=10.0,
-                rawrdf=True)
-
             data1 = pt.rdf(
                 traj,
                 solvent_mask=':5',
@@ -114,6 +106,14 @@ data01raw = pt.rdf(
                 maximum=10.0,
                 volume=True)
 
+            data8 = pt.rdf(
+                traj,
+                solvent_mask=':5@CD',
+                solute_mask=':WAT@O',
+                bin_spacing=0.5,
+                maximum=10.0,
+                raw_rdf=True)
+
             # do assertion
             aa_eq(data0[1], state.data[1], decimal=7)
             aa_eq(data1[1], state.data[2], decimal=7)
@@ -121,7 +121,7 @@ data01raw = pt.rdf(
             aa_eq(data3[1], state.data[4], decimal=7)
             aa_eq(data4[1], state.data[5], decimal=7)
             aa_eq(data7[1], state.data[8], decimal=7)
-            aa_eq(data01raw[1], state.data[9], decimal=7)
+            aa_eq(data8[1], state.data[10], decimal=7)
 
             # default solvent mask :WAT@O
             aa_eq(data01[1], state.data[1], decimal=7)


### PR DESCRIPTION
Hello everyone, 

I just updated the rdf action with an optional boolean argument `raw_rdf`.
When `raw_rdf` is set to True, the returned rdf values are not normalized, as the `rawrdf` argument in cpptraj.

