### PR TITLE
Chain ID is now a string as of cpptraj version 6.27.0

### DIFF
--- a/pytraj/core/topology_objects.pxd
+++ b/pytraj/core/topology_objects.pxd
@@ -70,7 +70,7 @@ cdef extern from "Residue.h":
     cdef cppclass _Residue "Residue":
         _Residue()
         _Residue(int onum, const _NameType& resname, int first_AtomIn)
-        _Residue(_NameType& n, int r, char ic, char cid)
+        _Residue(_NameType& n, int r, char ic, const string& cid)
         inline void SetLastAtom(int i)
         inline void SetOriginalNum(int i)
         inline int FirstAtom() const 

--- a/pytraj/core/topology_objects.pyx
+++ b/pytraj/core/topology_objects.pyx
@@ -163,13 +163,13 @@ cdef class Residue:
 
     Examples
     --------
-    >>> Residue('ALA', resid=0, icode=0, chainID=0)
+    >>> Residue('ALA', resid=0, icode=0, chainID='')
     '''
 
-    def __cinit__(self, name='', int resid=0, icode=0, chainID=0):
+    def __cinit__(self, name='', int resid=0, icode=0, chainID=''):
         cdef NameType resname = NameType(name)
         cdef char icode_ = <int> icode
-        cdef char chainID_ = <int> chainID
+        cdef string chainID_ = chainID.encode()
         self.thisptr = new _Residue(resname.thisptr[0], <int> resid,
                                     icode_, chainID_)
 


### PR DESCRIPTION
Chain ID is now a string in the Residue class to accommodate multi-character residue IDs, as well as better support segment IDs in CHARMM PSF files. See https://github.com/Amber-MD/cpptraj/pull/1086